### PR TITLE
Disable default features in curve25519 dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ travis-ci = { repository = "dalek-cryptography/x25519-dalek", branch = "master"}
 
 [dependencies.curve25519-dalek]
 version = "^0.12"
+default-features = false
 
 [dependencies.rand]
 optional = true


### PR DESCRIPTION
This disables default features in curve25519-dalek to make sure `std` crate does not leak through this crate into the libraries that have a replacement for `std`, `libc` etc (e.g. in SGX builds).
