### PR TITLE
Use latest curve25519-dalek.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,11 +19,11 @@ exclude = [
 travis-ci = { repository = "isislovecruft/x25519-dalek", branch = "master"}
 
 [dependencies.curve25519-dalek]
-version = "^0.12"
+version = "^0.16"
 
 [dependencies.rand]
 optional = true
-version = "^0.3"
+version = "^0.4"
 
 [features]
 bench = []


### PR DESCRIPTION
Fixes #5 (allows x25519-dalek to compile on stable).

informed by https://github.com/dalek-cryptography/curve25519-dalek/commit/6748dddb96897b9cf9d5ea8df0fdf5e6f14e654d:
  - sub `CompressedMontgomeryU` with `MontgomeryPoint`, removing
    (de)compress calls.

informed by https://github.com/dalek-cryptography/curve25519-dalek/commit/d32fe9772b296511638f662da75b71a41bc61eb6:
  - sub `Scalar([u8; 32])` with `Scalar::from_bits([u8; 32])`

This diff also ups the rand version since it was old, but that's independent of all the other changes.

And as an added bonus, handshake benchmarks in wireguard-rs are 15% faster with this version of x25519-dalek :).