### PR TITLE
Resolve rand dependency conflict

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ default-features = false
 
 [dependencies.rand]
 optional = true
-version = "=0.5.0-pre.2"
+version = "0.5.4"
 
 [dev-dependencies]
 criterion = "0.2"


### PR DESCRIPTION
Explicitly depending on `=0.5.0-pre.2` seems to prevent me from bumping my snow dependency due to dependency conflicts. Since 0.5.4 was released by now it might be a good idea to use that instead.