### PR TITLE
Create new types for keys and clear values on drop

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,9 @@ default-features = false
 default-features = false
 version = "0.2"
 
+[dependencies.clear_on_drop]
+version = "0.2"
+
 [dev-dependencies]
 criterion = "0.2"
 rand = "0.5"
@@ -38,6 +41,6 @@ harness = false
 [features]
 default = ["std", "nightly", "u64_backend"]
 std = ["curve25519-dalek/std"]
-nightly = ["curve25519-dalek/nightly"]
+nightly = ["curve25519-dalek/nightly", "clear_on_drop/nightly"]
 u64_backend = ["curve25519-dalek/u64_backend"]
 u32_backend = ["curve25519-dalek/u32_backend"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ version = "0.2"
 
 [dev-dependencies]
 criterion = "0.2"
-rand = "0.5"
+rand = "0.6"
 
 [[bench]]
 name = "x25519"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ exclude = [
 travis-ci = { repository = "dalek-cryptography/x25519-dalek", branch = "master"}
 
 [dependencies.curve25519-dalek]
-version = "^1.0.0-pre.1"
+version = "1"
 default-features = false
 
 [dependencies.rand_core]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ exclude = [
 travis-ci = { repository = "dalek-cryptography/x25519-dalek", branch = "master"}
 
 [dependencies.curve25519-dalek]
-version = "^0.19"
+version = "^1.0.0-pre.1"
 default-features = false
 
 [dependencies.rand_core]

--- a/README.md
+++ b/README.md
@@ -57,13 +57,13 @@ shared secret with Bob by doing:
 use x25519_dalek::EphemeralPublic;
 use x25519_dalek::EphemeralSecret;
 
-let shared_secret = EphemeralSecret::diffie_hellman(&alice_secret, &bob_public);
+let shared_secret = EphemeralSecret::diffie_hellman(alice_secret, &bob_public);
 ```
 
 Similarly, Bob computes the same shared secret by doing:
 
 ```rust
-let shared_secret = EphemeralSecret::diffie_hellman(&bob_secret, &alice_public);
+let shared_secret = EphemeralSecret::diffie_hellman(bob_secret, &alice_public);
 ```
 
 Voilá!  Alice and Bob can now use their shared secret to encrypt their

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ up on modern public key cryptography and have learned a nifty trick called
 kittens will be able to secretly organise to find their mittens, and then spend
 the rest of the afternoon nomming some yummy pie!
 
-First, Alice uses `x25519_dalek::Ephemeral::generate_secret()` and then
-`x25519_dalek::Ephemeral::generate_public()` to produce her secret and public keys:
+First, Alice uses `x25519_dalek::EphemeralSecret::new()` and then
+`x25519_dalek::EphemeralPublic::generate_public()` to produce her secret and public keys:
 
 ```rust
 extern crate x25519_dalek;
@@ -36,16 +36,16 @@ use x25519_dalek::Ephemeral;
 use rand::OsRng;
 
 let mut alice_csprng = OsRng::new().unwrap();
-let     alice_secret = Ephemeral::generate_secret(&mut alice_csprng);
-let     alice_public = Ephemeral::generate_public(&alice_secret);
+let     alice_secret = EphemeralSecret::new(&mut alice_csprng);
+let     alice_public = EphemeralPublic::generate_public(&alice_secret);
 ```
 
 Bob does the same:
 
 ```rust
 let mut bob_csprng = OsRng::new().unwrap();
-let     bob_secret = Ephemeral::generate_secret(&mut bob_csprng);
-let     bob_public = Ephemeral::generate_public(&bob_secret);
+let     bob_secret = EphemeralSecret::new(&mut bob_csprng);
+let     bob_public = EphemeralPublic::generate_public(&bob_secret);
 ```
 
 Alice meows across the room, telling `alice_public` to Bob, and Bob

--- a/README.md
+++ b/README.md
@@ -25,28 +25,27 @@ up on modern public key cryptography and have learned a nifty trick called
 kittens will be able to secretly organise to find their mittens, and then spend
 the rest of the afternoon nomming some yummy pie!
 
-First, Alice uses `x25519_dalek::generate_secret()` and then
-`x25519_dalek::generate_public()` to produce her secret and public keys:
+First, Alice uses `x25519_dalek::Ephemeral::generate_secret()` and then
+`x25519_dalek::Ephemeral::generate_public()` to produce her secret and public keys:
 
 ```rust
 extern crate x25519_dalek;
 extern crate rand;
 
-use x25519_dalek::generate_secret;
-use x25519_dalek::generate_public;
+use x25519_dalek::Ephemeral;
 use rand::OsRng;
 
 let mut alice_csprng = OsRng::new().unwrap();
-let     alice_secret = generate_secret(&mut alice_csprng);
-let     alice_public = generate_public(&alice_secret);
+let     alice_secret = Ephemeral::generate_secret(&mut alice_csprng);
+let     alice_public = Ephemeral::generate_public(&alice_secret);
 ```
 
 Bob does the same:
 
 ```rust
 let mut bob_csprng = OsRng::new().unwrap();
-let     bob_secret = generate_secret(&mut bob_csprng);
-let     bob_public = generate_public(&bob_secret);
+let     bob_secret = Ephemeral::generate_secret(&mut bob_csprng);
+let     bob_public = Ephemeral::generate_public(&bob_secret);
 ```
 
 Alice meows across the room, telling `alice_public` to Bob, and Bob
@@ -54,15 +53,15 @@ loudly meows `bob_public` back to Alice.  Alice now computes her
 shared secret with Bob by doing:
 
 ```rust
-use x25519_dalek::diffie_hellman;
+use x25519_dalek::Ephemeral;
 
-let shared_secret = diffie_hellman(&alice_secret, &bob_public.as_bytes());
+let shared_secret = Ephemeral::diffie_hellman(&alice_secret, &bob_public);
 ```
 
 Similarly, Bob computes the same shared secret by doing:
 
 ```rust
-let shared_secret = diffie_hellman(&bob_secret, &alice_public.as_bytes());
+let shared_secret = Ephemeral::diffie_hellman(&bob_secret, &alice_public);
 ```
 
 Voilá!  Alice and Bob can now use their shared secret to encrypt their

--- a/benches/x25519.rs
+++ b/benches/x25519.rs
@@ -21,17 +21,18 @@ use curve25519_dalek::montgomery::MontgomeryPoint;
 
 use rand::OsRng;
 
-use x25519_dalek::Ephemeral;
+use x25519_dalek::EphemeralPublic;
+use x25519_dalek::EphemeralSecret;
 
 fn bench_diffie_hellman(c: &mut Criterion) {
     let mut csprng: OsRng = OsRng::new().unwrap();
-    let alice_secret: Ephemeral = Ephemeral::generate_secret(&mut csprng);
-    let bob_secret: Ephemeral = Ephemeral::generate_secret(&mut csprng);
-    let bob_public: MontgomeryPoint = Ephemeral::generate_public(&bob_secret);
+    let alice_secret: EphemeralSecret = EphemeralSecret::new(&mut csprng);
+    let bob_secret: EphemeralSecret = EphemeralSecret::new(&mut csprng);
+    let bob_public: EphemeralPublic = EphemeralPublic::from(&bob_secret);
 
     c.bench_function("diffie_hellman", move |b| {
         b.iter(||
-               Ephemeral::diffie_hellman(&alice_secret, &bob_public)
+               EphemeralSecret::diffie_hellman(&alice_secret, &bob_public)
         )
     });
 }

--- a/benches/x25519.rs
+++ b/benches/x25519.rs
@@ -30,7 +30,6 @@ fn bench_diffie_hellman(c: &mut Criterion) {
     let bob_public: EphemeralPublic = EphemeralPublic::from(&bob_secret);
 
     c.bench_function("diffie_hellman", move |b| {
-        let alice_secret: EphemeralSecret = EphemeralSecret::new(&mut csprng);
         b.iter_with_setup(
             || EphemeralSecret::new(&mut csprng),
             |alice_secret| EphemeralSecret::diffie_hellman(alice_secret, &bob_public),

--- a/benches/x25519.rs
+++ b/benches/x25519.rs
@@ -26,13 +26,14 @@ use x25519_dalek::EphemeralSecret;
 
 fn bench_diffie_hellman(c: &mut Criterion) {
     let mut csprng: OsRng = OsRng::new().unwrap();
-    let alice_secret: EphemeralSecret = EphemeralSecret::new(&mut csprng);
     let bob_secret: EphemeralSecret = EphemeralSecret::new(&mut csprng);
     let bob_public: EphemeralPublic = EphemeralPublic::from(&bob_secret);
 
     c.bench_function("diffie_hellman", move |b| {
-        b.iter(||
-               EphemeralSecret::diffie_hellman(&alice_secret, &bob_public)
+        let alice_secret: EphemeralSecret = EphemeralSecret::new(&mut csprng);
+        b.iter_with_setup(
+            || EphemeralSecret::new(&mut csprng),
+            |alice_secret| EphemeralSecret::diffie_hellman(alice_secret, &bob_public),
         )
     });
 }

--- a/benches/x25519.rs
+++ b/benches/x25519.rs
@@ -11,26 +11,27 @@
 
 #[macro_use]
 extern crate criterion;
+extern crate curve25519_dalek;
 extern crate rand;
 extern crate x25519_dalek;
 
 use criterion::Criterion;
 
+use curve25519_dalek::montgomery::MontgomeryPoint;
+
 use rand::OsRng;
 
-use x25519_dalek::generate_public;
-use x25519_dalek::generate_secret;
-use x25519_dalek::diffie_hellman;
+use x25519_dalek::Ephemeral;
 
 fn bench_diffie_hellman(c: &mut Criterion) {
     let mut csprng: OsRng = OsRng::new().unwrap();
-    let alice_secret: [u8; 32] = generate_secret(&mut csprng);
-    let bob_secret: [u8; 32] = generate_secret(&mut csprng);
-    let bob_public: [u8; 32] = generate_public(&bob_secret).to_bytes();
+    let alice_secret: Ephemeral = Ephemeral::generate_secret(&mut csprng);
+    let bob_secret: Ephemeral = Ephemeral::generate_secret(&mut csprng);
+    let bob_public: MontgomeryPoint = Ephemeral::generate_public(&bob_secret);
 
     c.bench_function("diffie_hellman", move |b| {
         b.iter(||
-               diffie_hellman(&alice_secret, &bob_public)
+               Ephemeral::diffie_hellman(&alice_secret, &bob_public)
         )
     });
 }

--- a/benches/x25519.rs
+++ b/benches/x25519.rs
@@ -32,7 +32,7 @@ fn bench_diffie_hellman(c: &mut Criterion) {
     c.bench_function("diffie_hellman", move |b| {
         b.iter_with_setup(
             || EphemeralSecret::new(&mut csprng),
-            |alice_secret| EphemeralSecret::diffie_hellman(alice_secret, &bob_public),
+            |alice_secret| alice_secret.diffie_hellman(&bob_public),
         )
     });
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,6 +126,8 @@
 #![cfg_attr(feature = "bench", feature(test))]
 #![deny(missing_docs)]
 
+extern crate clear_on_drop;
+
 extern crate curve25519_dalek;
 
 extern crate rand_core;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,7 +89,7 @@
 //! # let     bob_public = EphemeralPublic::from(&bob_secret);
 //! #
 //! #
-//! let shared_secret = EphemeralSecret::diffie_hellman(&alice_secret, &bob_public);
+//! let shared_secret = EphemeralSecret::diffie_hellman(alice_secret, &bob_public);
 //! # }
 //! ```
 //!
@@ -112,7 +112,7 @@
 //! # let     bob_secret = EphemeralSecret::new(&mut bob_csprng);
 //! # let     bob_public = EphemeralPublic::from(&bob_secret);
 //! #
-//! let shared_secret = EphemeralSecret::diffie_hellman(&bob_secret, &alice_public);
+//! let shared_secret = EphemeralSecret::diffie_hellman(bob_secret, &alice_public);
 //! # }
 //! ```
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,21 +32,20 @@
 //! incantations, the kittens will be able to secretly organise to find their
 //! mittens, and then spend the rest of the afternoon nomming some yummy pie!
 //!
-//! First, Alice uses `x25519_dalek::generate_secret()` and
-//! `x25519_dalek::generate_public()` to produce her secret and public keys:
+//! First, Alice uses `x25519_dalek::Ephemeral::generate_secret()` and
+//! `x25519_dalek::Ephemeral::generate_public()` to produce her secret and public keys:
 //!
 //! ```
 //! extern crate x25519_dalek;
 //! extern crate rand;
 //!
 //! # fn main() {
-//! use x25519_dalek::generate_secret;
-//! use x25519_dalek::generate_public;
+//! use x25519_dalek::Ephemeral;
 //! use rand::thread_rng;
 //!
 //! let mut alice_csprng = thread_rng();
-//! let     alice_secret = generate_secret(&mut alice_csprng);
-//! let     alice_public = generate_public(&alice_secret);
+//! let     alice_secret = Ephemeral::generate_secret(&mut alice_csprng);
+//! let     alice_public = Ephemeral::generate_public(&alice_secret);
 //! # }
 //! ```
 //!
@@ -57,13 +56,12 @@
 //! # extern crate rand;
 //! #
 //! # fn main() {
-//! # use x25519_dalek::generate_secret;
-//! # use x25519_dalek::generate_public;
+//! # use x25519_dalek::Ephemeral;
 //! # use rand::thread_rng;
 //! #
 //! let mut bob_csprng = thread_rng();
-//! let     bob_secret = generate_secret(&mut bob_csprng);
-//! let     bob_public = generate_public(&bob_secret);
+//! let     bob_secret = Ephemeral::generate_secret(&mut bob_csprng);
+//! let     bob_public = Ephemeral::generate_public(&bob_secret);
 //! # }
 //! ```
 //!
@@ -76,21 +74,19 @@
 //! # extern crate rand;
 //! #
 //! # fn main() {
-//! # use x25519_dalek::generate_secret;
-//! # use x25519_dalek::generate_public;
+//! # use x25519_dalek::Ephemeral;
 //! # use rand::thread_rng;
 //! #
 //! # let mut alice_csprng = thread_rng();
-//! # let     alice_secret = generate_secret(&mut alice_csprng);
-//! # let     alice_public = generate_public(&alice_secret);
+//! # let     alice_secret = Ephemeral::generate_secret(&mut alice_csprng);
+//! # let     alice_public = Ephemeral::generate_public(&alice_secret);
 //! #
 //! # let mut bob_csprng = thread_rng();
-//! # let     bob_secret = generate_secret(&mut bob_csprng);
-//! # let     bob_public = generate_public(&bob_secret);
+//! # let     bob_secret = Ephemeral::generate_secret(&mut bob_csprng);
+//! # let     bob_public = Ephemeral::generate_public(&bob_secret);
 //! #
-//! use x25519_dalek::diffie_hellman;
 //!
-//! let shared_secret = diffie_hellman(&alice_secret, &bob_public.as_bytes());
+//! let shared_secret = Ephemeral::diffie_hellman(&alice_secret, &bob_public);
 //! # }
 //! ```
 //!
@@ -101,20 +97,18 @@
 //! # extern crate rand;
 //! #
 //! # fn main() {
-//! # use x25519_dalek::diffie_hellman;
-//! # use x25519_dalek::generate_secret;
-//! # use x25519_dalek::generate_public;
+//! # use x25519_dalek::Ephemeral;
 //! # use rand::thread_rng;
 //! #
 //! # let mut alice_csprng = thread_rng();
-//! # let     alice_secret = generate_secret(&mut alice_csprng);
-//! # let     alice_public = generate_public(&alice_secret);
+//! # let     alice_secret = Ephemeral::generate_secret(&mut alice_csprng);
+//! # let     alice_public = Ephemeral::generate_public(&alice_secret);
 //! #
 //! # let mut bob_csprng = thread_rng();
-//! # let     bob_secret = generate_secret(&mut bob_csprng);
-//! # let     bob_public = generate_public(&bob_secret);
+//! # let     bob_secret = Ephemeral::generate_secret(&mut bob_csprng);
+//! # let     bob_public = Ephemeral::generate_public(&bob_secret);
 //! #
-//! let shared_secret = diffie_hellman(&bob_secret, &alice_public.as_bytes());
+//! let shared_secret = Ephemeral::diffie_hellman(&bob_secret, &alice_public);
 //! # }
 //! ```
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,20 +32,21 @@
 //! incantations, the kittens will be able to secretly organise to find their
 //! mittens, and then spend the rest of the afternoon nomming some yummy pie!
 //!
-//! First, Alice uses `x25519_dalek::Ephemeral::generate_secret()` and
-//! `x25519_dalek::Ephemeral::generate_public()` to produce her secret and public keys:
+//! First, Alice uses `x25519_dalek::EphemeralSecret::new()` and
+//! `x25519_dalek::EphemeralPublic::from()` to produce her secret and public keys:
 //!
 //! ```
 //! extern crate x25519_dalek;
 //! extern crate rand;
 //!
 //! # fn main() {
-//! use x25519_dalek::Ephemeral;
+//! use x25519_dalek::EphemeralPublic;
+//! use x25519_dalek::EphemeralSecret;
 //! use rand::thread_rng;
 //!
 //! let mut alice_csprng = thread_rng();
-//! let     alice_secret = Ephemeral::generate_secret(&mut alice_csprng);
-//! let     alice_public = Ephemeral::generate_public(&alice_secret);
+//! let     alice_secret = EphemeralSecret::new(&mut alice_csprng);
+//! let     alice_public = EphemeralPublic::from(&alice_secret);
 //! # }
 //! ```
 //!
@@ -56,12 +57,13 @@
 //! # extern crate rand;
 //! #
 //! # fn main() {
-//! # use x25519_dalek::Ephemeral;
+//! # use x25519_dalek::EphemeralPublic;
+//! # use x25519_dalek::EphemeralSecret;
 //! # use rand::thread_rng;
 //! #
 //! let mut bob_csprng = thread_rng();
-//! let     bob_secret = Ephemeral::generate_secret(&mut bob_csprng);
-//! let     bob_public = Ephemeral::generate_public(&bob_secret);
+//! let     bob_secret = EphemeralSecret::new(&mut bob_csprng);
+//! let     bob_public = EphemeralPublic::from(&bob_secret);
 //! # }
 //! ```
 //!
@@ -74,19 +76,20 @@
 //! # extern crate rand;
 //! #
 //! # fn main() {
-//! # use x25519_dalek::Ephemeral;
+//! # use x25519_dalek::EphemeralPublic;
+//! # use x25519_dalek::EphemeralSecret;
 //! # use rand::thread_rng;
 //! #
 //! # let mut alice_csprng = thread_rng();
-//! # let     alice_secret = Ephemeral::generate_secret(&mut alice_csprng);
-//! # let     alice_public = Ephemeral::generate_public(&alice_secret);
+//! # let     alice_secret = EphemeralSecret::new(&mut alice_csprng);
+//! # let     alice_public = EphemeralPublic::from(&alice_secret);
 //! #
 //! # let mut bob_csprng = thread_rng();
-//! # let     bob_secret = Ephemeral::generate_secret(&mut bob_csprng);
-//! # let     bob_public = Ephemeral::generate_public(&bob_secret);
+//! # let     bob_secret = EphemeralSecret::new(&mut bob_csprng);
+//! # let     bob_public = EphemeralPublic::from(&bob_secret);
 //! #
 //!
-//! let shared_secret = Ephemeral::diffie_hellman(&alice_secret, &bob_public);
+//! let shared_secret = EphemeralSecret::diffie_hellman(&alice_secret, &bob_public);
 //! # }
 //! ```
 //!
@@ -97,18 +100,19 @@
 //! # extern crate rand;
 //! #
 //! # fn main() {
-//! # use x25519_dalek::Ephemeral;
+//! # use x25519_dalek::EphemeralPublic;
+//! # use x25519_dalek::EphemeralSecret;
 //! # use rand::thread_rng;
 //! #
 //! # let mut alice_csprng = thread_rng();
-//! # let     alice_secret = Ephemeral::generate_secret(&mut alice_csprng);
-//! # let     alice_public = Ephemeral::generate_public(&alice_secret);
+//! # let     alice_secret = EphemeralSecret::new(&mut alice_csprng);
+//! # let     alice_public = EphemeralPublic::from(&alice_secret);
 //! #
 //! # let mut bob_csprng = thread_rng();
-//! # let     bob_secret = Ephemeral::generate_secret(&mut bob_csprng);
-//! # let     bob_public = Ephemeral::generate_public(&bob_secret);
+//! # let     bob_secret = EphemeralSecret::new(&mut bob_csprng);
+//! # let     bob_public = EphemeralPublic::from(&bob_secret);
 //! #
-//! let shared_secret = Ephemeral::diffie_hellman(&bob_secret, &alice_public);
+//! let shared_secret = EphemeralSecret::diffie_hellman(&bob_secret, &alice_public);
 //! # }
 //! ```
 //!

--- a/src/x25519.rs
+++ b/src/x25519.rs
@@ -69,10 +69,10 @@ impl EphemeralSecret {
 
 }
 
-impl From<&EphemeralSecret> for EphemeralPublic {
+impl<'a> From<&'a EphemeralSecret> for EphemeralPublic {
     /// Given an x25519 `EphemeralSecret` key, compute its corresponding
     /// `EphemeralPublic` key.
-    fn from(secret: &EphemeralSecret) -> EphemeralPublic {
+    fn from(secret: &'a EphemeralSecret) -> EphemeralPublic {
         EphemeralPublic((&ED25519_BASEPOINT_TABLE * &secret.0).to_montgomery())
     }
 

--- a/src/x25519.rs
+++ b/src/x25519.rs
@@ -25,6 +25,14 @@ use rand_core::CryptoRng;
 #[repr(C)]
 pub struct EphemeralPublic(pub (crate) MontgomeryPoint);
 
+impl From<[u8; 32]> for EphemeralPublic {
+    /// Given a byte array, construct an x25519 `EphemeralPublic` key
+    fn from(bytes: [u8; 32]) -> EphemeralPublic {
+        EphemeralPublic(MontgomeryPoint(bytes))
+    }
+
+}
+
 /// A DH ephemeral secret key.
 #[repr(C)]
 #[derive(Default)] // we derive Default in order to use the clear() method in Drop

--- a/src/x25519.rs
+++ b/src/x25519.rs
@@ -113,7 +113,7 @@ fn decode_scalar(scalar: &[u8; 32]) -> Scalar {
 }
 
 /// The x25519 function, as specified in RFC7748.
-pub fn x25519(scalar: &Scalar, point: &MontgomeryPoint) -> MontgomeryPoint {
+fn x25519(scalar: &Scalar, point: &MontgomeryPoint) -> MontgomeryPoint {
     let k: Scalar = decode_scalar(scalar.as_bytes());
 
     (k * point)

--- a/src/x25519.rs
+++ b/src/x25519.rs
@@ -94,9 +94,9 @@ pub fn generate_public(secret: &SecretKey) -> MontgomeryPoint {
 
 /// The x25519 function, as specified in RFC7748.
 pub fn x25519(scalar: &Scalar, point: &MontgomeryPoint) -> MontgomeryPoint {
-    //let k: Scalar = decode_scalar(scalar);
+    let k: Scalar = decode_scalar(scalar.as_bytes());
 
-    (scalar * point)
+    (k * point)
 }
 
 /// Utility function to make it easier to call `x25519()` with byte arrays as

--- a/src/x25519.rs
+++ b/src/x25519.rs
@@ -12,6 +12,10 @@
 //! This implements x25519 key exchange as specified by Mike Hamburg
 //! and Adam Langley in [RFC7748](https://tools.ietf.org/html/rfc7748).
 
+use core::fmt::{Debug};
+
+use clear_on_drop::clear::Clear;
+
 use curve25519_dalek::constants::ED25519_BASEPOINT_TABLE;
 use curve25519_dalek::montgomery::MontgomeryPoint;
 use curve25519_dalek::scalar::Scalar;
@@ -19,6 +23,26 @@ use curve25519_dalek::scalar::Scalar;
 use rand_core::RngCore;
 use rand_core::CryptoRng;
 
+/// The length of a curve25519 EdDSA `SecretKey`, in bytes.
+pub const SECRET_KEY_LENGTH: usize = 32;
+
+/// An EdDSA secret key.
+#[repr(C)]
+#[derive(Default)] // we derive Default in order to use the clear() method in Drop
+pub struct SecretKey(pub (crate) [u8; SECRET_KEY_LENGTH]);
+
+impl Debug for SecretKey {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        write!(f, "SecretKey: {:?}", &self.0[..])
+    }
+}
+
+/// Overwrite secret key material with null bytes when it goes out of scope.
+impl Drop for SecretKey {
+    fn drop(&mut self) {
+        self.0.clear();
+    }
+}
 /// "Decode" a scalar from a 32-byte array.
 ///
 /// By "decode" here, what is really meant is applying key clamping by twiddling

--- a/src/x25519.rs
+++ b/src/x25519.rs
@@ -22,7 +22,6 @@ use rand_core::RngCore;
 use rand_core::CryptoRng;
 
 /// A DH ephemeral public key.
-#[repr(C)]
 pub struct EphemeralPublic(pub (crate) MontgomeryPoint);
 
 impl From<[u8; 32]> for EphemeralPublic {
@@ -34,8 +33,6 @@ impl From<[u8; 32]> for EphemeralPublic {
 }
 
 /// A DH ephemeral secret key.
-#[repr(C)]
-#[derive(Default)] // we derive Default in order to use the clear() method in Drop
 pub struct EphemeralSecret(pub (crate) Scalar);
 
 /// Overwrite ephemeral secret key material with null bytes when it goes out of scope.
@@ -46,13 +43,11 @@ impl Drop for EphemeralSecret {
 }
 
 impl EphemeralSecret {
-    /// The diffie_hellman function performs scalar multipication on a montegomery point.
-    /// This is the implementation for the x25519 function, as specified in RFC7748.
+    /// Utility function to make it easier to call `x25519()` with
+    /// an ephemeral secret key and montegomery point as input and
+    /// a shared secret as the output.
     pub fn diffie_hellman(self, their_public: &EphemeralPublic) -> SharedSecret {
-        let k: Scalar = clamp_scalar(self.0.as_bytes());
-        let point: MontgomeryPoint = MontgomeryPoint(*their_public.0.as_bytes());
-
-        SharedSecret(k * point)
+        SharedSecret(self.0 * their_public.0)
     }
 
     /// Generate an x25519 `EphemeralSecret` key.
@@ -63,7 +58,7 @@ impl EphemeralSecret {
 
         csprng.fill_bytes(&mut bytes);
 
-        EphemeralSecret(clamp_scalar(&bytes))
+        EphemeralSecret(clamp_scalar(bytes))
     }
 
 }
@@ -78,7 +73,6 @@ impl<'a> From<&'a EphemeralSecret> for EphemeralPublic {
 }
 
 /// A DH SharedSecret
-#[repr(C)]
 pub struct SharedSecret(pub (crate) MontgomeryPoint);
 
 /// Overwrite shared secret material with null bytes when it goes out of scope.
@@ -105,7 +99,7 @@ impl SharedSecret {
 /// # Returns
 ///
 /// A `Scalar`.
-fn clamp_scalar(scalar: &[u8; 32]) -> Scalar {
+fn clamp_scalar(scalar: [u8; 32]) -> Scalar {
     let mut s: [u8; 32] = scalar.clone();
 
     s[0]  &= 248;
@@ -115,58 +109,63 @@ fn clamp_scalar(scalar: &[u8; 32]) -> Scalar {
     Scalar::from_bits(s)
 }
 
+/// The x25519 function, as specified in RFC7748.
+pub fn x25519(k: [u8; 32], u: [u8; 32]) -> [u8; 32] {
+    (clamp_scalar(k) * MontgomeryPoint(u)).to_bytes()
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
 
-    fn do_rfc7748_ladder_test1(input_scalar: &Scalar,
-                               input_point: &MontgomeryPoint,
-                               expected: &[u8; 32]) {
-        let result = EphemeralSecret::diffie_hellman(EphemeralSecret(*input_scalar), &EphemeralPublic(*input_point));
+    fn do_rfc7748_ladder_test1(input_scalar: [u8; 32],
+                               input_point: [u8; 32],
+                               expected: [u8; 32]) {
+        let result = x25519(input_scalar, input_point);
 
-        assert_eq!(result.0, MontgomeryPoint(*expected));
+        assert_eq!(result, expected);
     }
 
     #[test]
     fn rfc7748_ladder_test1_vectorset1() {
-        let input_scalar: Scalar = Scalar::from_bits([
+        let input_scalar: [u8; 32] = [
             0xa5, 0x46, 0xe3, 0x6b, 0xf0, 0x52, 0x7c, 0x9d,
             0x3b, 0x16, 0x15, 0x4b, 0x82, 0x46, 0x5e, 0xdd,
             0x62, 0x14, 0x4c, 0x0a, 0xc1, 0xfc, 0x5a, 0x18,
-            0x50, 0x6a, 0x22, 0x44, 0xba, 0x44, 0x9a, 0xc4, ]);
-        let input_point: MontgomeryPoint = MontgomeryPoint([
+            0x50, 0x6a, 0x22, 0x44, 0xba, 0x44, 0x9a, 0xc4, ];
+        let input_point: [u8; 32] = [
             0xe6, 0xdb, 0x68, 0x67, 0x58, 0x30, 0x30, 0xdb,
             0x35, 0x94, 0xc1, 0xa4, 0x24, 0xb1, 0x5f, 0x7c,
             0x72, 0x66, 0x24, 0xec, 0x26, 0xb3, 0x35, 0x3b,
-            0x10, 0xa9, 0x03, 0xa6, 0xd0, 0xab, 0x1c, 0x4c, ]);
+            0x10, 0xa9, 0x03, 0xa6, 0xd0, 0xab, 0x1c, 0x4c, ];
         let expected: [u8; 32] = [
             0xc3, 0xda, 0x55, 0x37, 0x9d, 0xe9, 0xc6, 0x90,
             0x8e, 0x94, 0xea, 0x4d, 0xf2, 0x8d, 0x08, 0x4f,
             0x32, 0xec, 0xcf, 0x03, 0x49, 0x1c, 0x71, 0xf7,
             0x54, 0xb4, 0x07, 0x55, 0x77, 0xa2, 0x85, 0x52, ];
 
-        do_rfc7748_ladder_test1(&input_scalar, &input_point, &expected);
+        do_rfc7748_ladder_test1(input_scalar, input_point, expected);
     }
 
     #[test]
     fn rfc7748_ladder_test1_vectorset2() {
-        let input_scalar: Scalar = Scalar::from_bits([
+        let input_scalar: [u8; 32] = [
             0x4b, 0x66, 0xe9, 0xd4, 0xd1, 0xb4, 0x67, 0x3c,
             0x5a, 0xd2, 0x26, 0x91, 0x95, 0x7d, 0x6a, 0xf5,
             0xc1, 0x1b, 0x64, 0x21, 0xe0, 0xea, 0x01, 0xd4,
-            0x2c, 0xa4, 0x16, 0x9e, 0x79, 0x18, 0xba, 0x0d, ]);
-        let input_point: MontgomeryPoint = MontgomeryPoint([
+            0x2c, 0xa4, 0x16, 0x9e, 0x79, 0x18, 0xba, 0x0d, ];
+        let input_point: [u8; 32] = [
             0xe5, 0x21, 0x0f, 0x12, 0x78, 0x68, 0x11, 0xd3,
             0xf4, 0xb7, 0x95, 0x9d, 0x05, 0x38, 0xae, 0x2c,
             0x31, 0xdb, 0xe7, 0x10, 0x6f, 0xc0, 0x3c, 0x3e,
-            0xfc, 0x4c, 0xd5, 0x49, 0xc7, 0x15, 0xa4, 0x93, ]);
+            0xfc, 0x4c, 0xd5, 0x49, 0xc7, 0x15, 0xa4, 0x93, ];
         let expected: [u8; 32] = [
             0x95, 0xcb, 0xde, 0x94, 0x76, 0xe8, 0x90, 0x7d,
             0x7a, 0xad, 0xe4, 0x5c, 0xb4, 0xb8, 0x73, 0xf8,
             0x8b, 0x59, 0x5a, 0x68, 0x79, 0x9f, 0xa1, 0x52,
             0xe6, 0xf8, 0xf7, 0x64, 0x7a, 0xac, 0x79, 0x57, ];
 
-        do_rfc7748_ladder_test1(&input_scalar, &input_point, &expected);
+        do_rfc7748_ladder_test1(input_scalar, input_point, expected);
     }
 
     #[test]
@@ -174,14 +173,14 @@ mod test {
     fn rfc7748_ladder_test2() {
         use curve25519_dalek::constants::X25519_BASEPOINT;
 
-        let mut k: Scalar = Scalar::from_bits(X25519_BASEPOINT.0);
-        let mut u: MontgomeryPoint = X25519_BASEPOINT;
-        let mut result: SharedSecret;
+        let mut k: [u8; 32] = X25519_BASEPOINT.0;
+        let mut u: [u8; 32] = X25519_BASEPOINT.0;
+        let mut result: [u8; 32];
 
         macro_rules! do_iterations {
             ($n:expr) => (
                 for _ in 0..$n {
-                    result = EphemeralSecret::diffie_hellman(EphemeralSecret(k), &EphemeralPublic(u));
+                    result = x25519(k, u);
                     // OBVIOUS THING THAT I'M GOING TO NOTE ANYWAY BECAUSE I'VE
                     // SEEN PEOPLE DO THIS WITH GOLANG'S STDLIB AND YOU SURE AS
                     // HELL SHOULDN'T DO HORRIBLY STUPID THINGS LIKE THIS WITH
@@ -190,8 +189,8 @@ mod test {
                     // NEVER EVER TREAT SCALARS AS POINTS AND/OR VICE VERSA.
                     //
                     //                ↓↓ DON'T DO THIS ↓↓
-                    u = MontgomeryPoint(k.as_bytes().clone());
-                    k = Scalar::from_bits(result.0.to_bytes());
+                    u = k.clone();
+                    k = result;
                 }
             )
         }
@@ -204,19 +203,19 @@ mod test {
         //     7c3911e0ab2586fd864497297e575e6f3bc601c0883c30df5f4dd2d24f665424
 
         do_iterations!(1);
-        assert_eq!(k.as_bytes(), &[ 0x42, 0x2c, 0x8e, 0x7a, 0x62, 0x27, 0xd7, 0xbc,
-                                    0xa1, 0x35, 0x0b, 0x3e, 0x2b, 0xb7, 0x27, 0x9f,
-                                    0x78, 0x97, 0xb8, 0x7b, 0xb6, 0x85, 0x4b, 0x78,
-                                    0x3c, 0x60, 0xe8, 0x03, 0x11, 0xae, 0x30, 0x79, ]);
+        assert_eq!(k, [ 0x42, 0x2c, 0x8e, 0x7a, 0x62, 0x27, 0xd7, 0xbc,
+                        0xa1, 0x35, 0x0b, 0x3e, 0x2b, 0xb7, 0x27, 0x9f,
+                        0x78, 0x97, 0xb8, 0x7b, 0xb6, 0x85, 0x4b, 0x78,
+                        0x3c, 0x60, 0xe8, 0x03, 0x11, 0xae, 0x30, 0x79, ]);
         do_iterations!(999);
-        assert_eq!(k.as_bytes(), &[ 0x68, 0x4c, 0xf5, 0x9b, 0xa8, 0x33, 0x09, 0x55,
-                                    0x28, 0x00, 0xef, 0x56, 0x6f, 0x2f, 0x4d, 0x3c,
-                                    0x1c, 0x38, 0x87, 0xc4, 0x93, 0x60, 0xe3, 0x87,
-                                    0x5f, 0x2e, 0xb9, 0x4d, 0x99, 0x53, 0x2c, 0x51, ]);
+        assert_eq!(k, [ 0x68, 0x4c, 0xf5, 0x9b, 0xa8, 0x33, 0x09, 0x55,
+                        0x28, 0x00, 0xef, 0x56, 0x6f, 0x2f, 0x4d, 0x3c,
+                        0x1c, 0x38, 0x87, 0xc4, 0x93, 0x60, 0xe3, 0x87,
+                        0x5f, 0x2e, 0xb9, 0x4d, 0x99, 0x53, 0x2c, 0x51, ]);
         do_iterations!(999_000);
-        assert_eq!(k.as_bytes(), &[ 0x7c, 0x39, 0x11, 0xe0, 0xab, 0x25, 0x86, 0xfd,
-                                    0x86, 0x44, 0x97, 0x29, 0x7e, 0x57, 0x5e, 0x6f,
-                                    0x3b, 0xc6, 0x01, 0xc0, 0x88, 0x3c, 0x30, 0xdf,
-                                    0x5f, 0x4d, 0xd2, 0xd2, 0x4f, 0x66, 0x54, 0x24, ]);
+        assert_eq!(k, [ 0x7c, 0x39, 0x11, 0xe0, 0xab, 0x25, 0x86, 0xfd,
+                        0x86, 0x44, 0x97, 0x29, 0x7e, 0x57, 0x5e, 0x6f,
+                        0x3b, 0xc6, 0x01, 0xc0, 0x88, 0x3c, 0x30, 0xdf,
+                        0x5f, 0x4d, 0xd2, 0xd2, 0x4f, 0x66, 0x54, 0x24, ]);
     }
 }


### PR DESCRIPTION
PR for issue #9 

Created `Ephemeral` & `SharedSecret` types to use for keys. 
`diffie_hellman`, `generate_public`, & `generate_secret` are now methods on `Ephemeral`. 
Both types use `clear` in their respective `drop` implementations & `Ephemeral` has an implementation for `Mul`.