### PR TITLE
Removed "nightly" from default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ name = "x25519"
 harness = false
 
 [features]
-default = ["std", "nightly", "u64_backend"]
+default = ["std", "u64_backend"]
 std = ["curve25519-dalek/std"]
 nightly = ["curve25519-dalek/nightly", "clear_on_drop/nightly"]
 u64_backend = ["curve25519-dalek/u64_backend"]


### PR DESCRIPTION
I was using this crate and was surprised to have a compile error when switching to "stable". The error came from `subtle` trying to use a `#![feature(...)]` gate. I spent some time tracking down what was using `subtle` with the "nightly" feature flag set. I checked `curve25519-dalek` and `ed25519-dalek` and neither of them set "nightly" by default. I found it a bit surprising, then, that `x25519-dalek` was the culprit.

So, in keeping with `curve25519-dalek`, `ed25519-dalek`, `subtle`, and `zkp`, I think this should compile by default on "stable".