### PR TITLE
Static secret keys

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ rust:
 
 env:
   - TEST_COMMAND=test EXTRA_FLAGS='' FEATURES='default'
+  - TEST_COMMAND=test EXTRA_FLAGS='' FEATURES='nightly'
   - TEST_COMMAND=bench EXTRA_FLAGS='' FEATURES='default'
   - TEST_COMMAND=build EXTRA_FLAGS='--no-default-features' FEATURES='u32_backend nightly'
   - TEST_COMMAND=build EXTRA_FLAGS='--no-default-features' FEATURES='u64_backend nightly'

--- a/benches/x25519.rs
+++ b/benches/x25519.rs
@@ -23,13 +23,13 @@ use curve25519_dalek::montgomery::MontgomeryPoint;
 
 use rand_os::OsRng;
 
-use x25519_dalek::EphemeralPublic;
+use x25519_dalek::PublicKey;
 use x25519_dalek::EphemeralSecret;
 
 fn bench_diffie_hellman(c: &mut Criterion) {
     let mut csprng: OsRng = OsRng::new().unwrap();
-    let bob_secret: EphemeralSecret = EphemeralSecret::new(&mut csprng);
-    let bob_public: EphemeralPublic = EphemeralPublic::from(&bob_secret);
+    let bob_secret = EphemeralSecret::new(&mut csprng);
+    let bob_public = PublicKey::from(&bob_secret);
 
     c.bench_function("diffie_hellman", move |b| {
         b.iter_with_setup(

--- a/src/x25519.rs
+++ b/src/x25519.rs
@@ -110,6 +110,18 @@ impl StaticSecret {
         StaticSecret(clamp_scalar(bytes))
     }
 
+    /// Convert a x25519 `StaticSecret` key to its underlying sequence of bytes.
+    pub fn to_bytes(&self) -> [u8; 32] {
+        self.0.to_bytes()
+    }
+
+}
+
+impl From<[u8; 32]> for StaticSecret {
+    /// Given a byte array, construct a x25519 `StaticSecret`.
+    fn from(bytes: [u8; 32]) -> StaticSecret {
+        StaticSecret(Scalar::from_bits(bytes))
+    }
 }
 
 impl<'a> From<&'a StaticSecret> for PublicKey {

--- a/src/x25519.rs
+++ b/src/x25519.rs
@@ -23,18 +23,18 @@ use curve25519_dalek::scalar::Scalar;
 use rand_core::RngCore;
 use rand_core::CryptoRng;
 
-/// A DH ephemeral public key.
-pub struct EphemeralPublic(pub (crate) MontgomeryPoint);
+/// A DH public key.
+pub struct PublicKey(pub (crate) MontgomeryPoint);
 
-impl From<[u8; 32]> for EphemeralPublic {
-    /// Given a byte array, construct an x25519 `EphemeralPublic` key
-    fn from(bytes: [u8; 32]) -> EphemeralPublic {
-        EphemeralPublic(MontgomeryPoint(bytes))
+impl From<[u8; 32]> for PublicKey {
+    /// Given a byte array, construct a x25519 `PublicKey`.
+    fn from(bytes: [u8; 32]) -> PublicKey {
+        PublicKey(MontgomeryPoint(bytes))
     }
 }
 
-impl EphemeralPublic {
-    /// View this ephemeral public key as a byte array.
+impl PublicKey {
+    /// View this public key as a byte array.
     #[inline]
     pub fn as_bytes(&self) -> &[u8; 32] {
         self.0.as_bytes()
@@ -55,7 +55,7 @@ impl EphemeralSecret {
     /// Utility function to make it easier to call `x25519()` with
     /// an ephemeral secret key and montegomery point as input and
     /// a shared secret as the output.
-    pub fn diffie_hellman(self, their_public: &EphemeralPublic) -> SharedSecret {
+    pub fn diffie_hellman(self, their_public: &PublicKey) -> SharedSecret {
         SharedSecret(self.0 * their_public.0)
     }
 
@@ -72,11 +72,11 @@ impl EphemeralSecret {
 
 }
 
-impl<'a> From<&'a EphemeralSecret> for EphemeralPublic {
+impl<'a> From<&'a EphemeralSecret> for PublicKey {
     /// Given an x25519 `EphemeralSecret` key, compute its corresponding
-    /// `EphemeralPublic` key.
-    fn from(secret: &'a EphemeralSecret) -> EphemeralPublic {
-        EphemeralPublic((&ED25519_BASEPOINT_TABLE * &secret.0).to_montgomery())
+    /// `PublicKey` key.
+    fn from(secret: &'a EphemeralSecret) -> PublicKey {
+        PublicKey((&ED25519_BASEPOINT_TABLE * &secret.0).to_montgomery())
     }
 
 }

--- a/src/x25519.rs
+++ b/src/x25519.rs
@@ -122,7 +122,7 @@ impl StaticSecret {
 impl From<[u8; 32]> for StaticSecret {
     /// Load a `StaticSecret` from a byte array.
     fn from(bytes: [u8; 32]) -> StaticSecret {
-        StaticSecret(Scalar::from_bits(bytes))
+        StaticSecret(clamp_scalar(bytes))
     }
 }
 

--- a/src/x25519.rs
+++ b/src/x25519.rs
@@ -23,7 +23,8 @@ use curve25519_dalek::scalar::Scalar;
 use rand_core::RngCore;
 use rand_core::CryptoRng;
 
-/// A DH public key.
+/// A `PublicKey` is the corresponding public key converted from
+/// an `EphemeralSecret` or a `StaticSecret` key.
 pub struct PublicKey(pub (crate) MontgomeryPoint);
 
 impl From<[u8; 32]> for PublicKey {
@@ -41,7 +42,8 @@ impl PublicKey {
     }
 }
 
-/// A DH ephemeral secret key.
+/// A `EphemeralSecret` is a short lived Diffie-Hellman secret key
+/// used to create a `SharedSecret` when given their `PublicKey`.
 pub struct EphemeralSecret(pub (crate) Scalar);
 
 /// Overwrite ephemeral secret key material with null bytes when it goes out of scope.
@@ -80,9 +82,9 @@ impl<'a> From<&'a EphemeralSecret> for PublicKey {
 
 }
 
-/// A static secret key for Diffie-Hellman. Unlike an EphemeralSecret, this key
-/// does not enforce that it's used only once, and can be saved and loaded from
-/// a byte array.
+/// A `StaticSecret` is a static Diffie-Hellman secret key that
+/// can be saved and loaded to create a `SharedSecret` when given
+/// their `PublicKey`.
 pub struct StaticSecret(pub (crate) Scalar);
 
 /// Overwrite static secret key material with null bytes when it goes out of scope.
@@ -133,7 +135,8 @@ impl<'a> From<&'a StaticSecret> for PublicKey {
 
 }
 
-/// A DH SharedSecret
+/// A `SharedSecret` is a Diffie-Hellman shared secret that’s generated
+/// from your `EphemeralSecret` or `StaticSecret` and their `PublicKey`.
 pub struct SharedSecret(pub (crate) MontgomeryPoint);
 
 /// Overwrite shared secret material with null bytes when it goes out of scope.


### PR DESCRIPTION
Currently, the API uses only ephemeral secret keys for Diffie-Hellman & everything else is forced to use the bare `x25519` function.

This PR implements another secret key type. We have two secret key types, 'EphemeralSecret' & 'StaticSecret', & one public key type, 'PublicKey`. This enables users to be able to save & load secret keys using `StaticSecret` & allows us to use the same logic to create `PublicKey`s from both secret key types. 

In a key exchange, you don't have a way to know whether or not they'll ever reuse their secret key. Since creating a `PublicKey` is a conversion from a secret key, this name better reflects that the value might not be ephemeral.