### PR TITLE
Made StaticSecret cloneable

### DIFF
--- a/src/x25519.rs
+++ b/src/x25519.rs
@@ -86,6 +86,7 @@ impl<'a> From<&'a EphemeralSecret> for PublicKey {
 /// A `StaticSecret` is a static Diffie-Hellman secret key that
 /// can be saved and loaded to create a `SharedSecret` when given
 /// their `PublicKey`.
+#[derive(Clone)]
 pub struct StaticSecret(pub (crate) Scalar);
 
 /// Overwrite static secret key material with null bytes when it goes out of scope.


### PR DESCRIPTION
I ran into this issue in practice. My use case: I have a TreeKEM tree of private keys that needs updating, but the update operation is fallible. So I run the update on a clone of the tree, and if it fails, I rollback and delete the clone.