### PR TITLE
Implement subtle::ConstantTimeEq on x25519 secret types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ features = ["nightly"]
 curve25519-dalek = { version = "1", default-features = false }
 rand_core = { version = "0.3", default-features = false }
 clear_on_drop = { version = "0.2" }
+subtle = { version = "2", default-features = false }
 
 [dev-dependencies]
 criterion = "0.2"
@@ -43,6 +44,6 @@ harness = false
 [features]
 default = ["std", "u64_backend"]
 std = ["curve25519-dalek/std"]
-nightly = ["curve25519-dalek/nightly", "clear_on_drop/nightly"]
+nightly = ["curve25519-dalek/nightly", "clear_on_drop/nightly", "subtle/nightly"]
 u64_backend = ["curve25519-dalek/u64_backend"]
 u32_backend = ["curve25519-dalek/u32_backend"]

--- a/src/x25519.rs
+++ b/src/x25519.rs
@@ -23,6 +23,9 @@ use curve25519_dalek::scalar::Scalar;
 use rand_core::RngCore;
 use rand_core::CryptoRng;
 
+use subtle::Choice;
+use subtle::ConstantTimeEq;
+
 /// A `PublicKey` is the corresponding public key converted from
 /// an `EphemeralSecret` or a `StaticSecret` key.
 #[derive(Copy, Clone, Debug)]
@@ -51,6 +54,12 @@ pub struct EphemeralSecret(pub (crate) Scalar);
 impl Drop for EphemeralSecret {
     fn drop(&mut self) {
         self.0.clear();
+    }
+}
+
+impl ConstantTimeEq for EphemeralSecret {
+    fn ct_eq(&self, other: &Self) -> Choice {
+        self.0.ct_eq(&other.0)
     }
 }
 
@@ -93,6 +102,12 @@ pub struct StaticSecret(pub (crate) Scalar);
 impl Drop for StaticSecret {
     fn drop(&mut self) {
         self.0.clear();
+    }
+}
+
+impl ConstantTimeEq for StaticSecret {
+    fn ct_eq(&self, other: &Self) -> Choice {
+        self.0.ct_eq(&other.0)
     }
 }
 


### PR DESCRIPTION
This is already implemented on `curve25519::Scalar`, we just have
to forward it around the newtype wrapper.

There is no way for the user to do this otherwise for some of these,
since the newtype wrapper doesn't allow access to the bytes of the
secret in case of ephemeral secret.