### PR TITLE
Bump rand_core Version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ features = ["nightly"]
 
 [dependencies]
 curve25519-dalek = { version = "2", default-features = false }
-rand_core = { version = "0.3", default-features = false }
+rand_core = { version = "0.5", default-features = false }
 # `serde` is renamed to `our_serde` in order to avoid a name collision between
 # importing the serde dependency and enabling the curve25519-dalek/serde feature
 our_serde = { package = "serde", version = "1", default-features = false, optional = true, features = ["derive"] }
@@ -39,7 +39,6 @@ zeroize = { version = "1", default-features = false, features = ["zeroize_derive
 [dev-dependencies]
 bincode = "1"
 criterion = "0.2"
-rand_os = "0.1"
 
 [[bench]]
 name = "x25519"

--- a/benches/x25519.rs
+++ b/benches/x25519.rs
@@ -14,24 +14,23 @@
 #[macro_use]
 extern crate criterion;
 extern crate curve25519_dalek;
-extern crate rand_os;
+extern crate rand_core;
 extern crate x25519_dalek;
 
 use criterion::Criterion;
 
-use rand_os::OsRng;
+use rand_core::OsRng;
 
 use x25519_dalek::EphemeralSecret;
 use x25519_dalek::PublicKey;
 
 fn bench_diffie_hellman(c: &mut Criterion) {
-    let mut csprng: OsRng = OsRng::new().unwrap();
-    let bob_secret = EphemeralSecret::new(&mut csprng);
+    let bob_secret = EphemeralSecret::new(&mut OsRng);
     let bob_public = PublicKey::from(&bob_secret);
 
     c.bench_function("diffie_hellman", move |b| {
         b.iter_with_setup(
-            || EphemeralSecret::new(&mut csprng),
+            || EphemeralSecret::new(&mut OsRng),
             |alice_secret| alice_secret.diffie_hellman(&bob_public),
         )
     });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,9 +30,6 @@ extern crate rand_core;
 
 extern crate zeroize;
 
-#[cfg(test)]
-extern crate rand_os;
-
 mod x25519;
 
 pub use crate::x25519::*;

--- a/src/x25519.rs
+++ b/src/x25519.rs
@@ -203,17 +203,16 @@ impl From<AllowUnreducedScalarBytes> for Scalar {
 mod test {
     use super::*;
 
-    use rand_os::OsRng;
+    use rand_core::OsRng;
 
     // This was previously a doctest but it got moved to the README to
     // avoid duplication where it then wasn't being run, so now it
     // lives here.
     #[test]
     fn alice_and_bob() {
-        let mut csprng = OsRng::new().unwrap();
-        let alice_secret = EphemeralSecret::new(&mut csprng);
+        let alice_secret = EphemeralSecret::new(&mut OsRng);
         let alice_public = PublicKey::from(&alice_secret);
-        let bob_secret = EphemeralSecret::new(&mut csprng);
+        let bob_secret = EphemeralSecret::new(&mut OsRng);
         let bob_public = PublicKey::from(&bob_secret);
         let alice_shared_secret = alice_secret.diffie_hellman(&bob_public);
         let bob_shared_secret = bob_secret.diffie_hellman(&alice_public);


### PR DESCRIPTION
This PR bumps the rand_core version.

This work follows from https://github.com/dalek-cryptography/x25519-dalek/pull/45 with attribution and this PR was made instead because it would've been more difficult to get that branch updated to merge it cleanly.