### PR TITLE
README.md: Add "See also" section with link to `crypto_box` crate

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,3 +105,11 @@ attempt to prevent software side-channels.
 copyright © Amy Wibowo ([@sailorhg](https://twitter.com/sailorhg))
 
 [rfc7748]: https://tools.ietf.org/html/rfc7748
+
+# See also
+
+- [crypto_box]: pure Rust public-key authenticated encryption compatible with
+  the NaCl family of encryption libraries (libsodium, TweetNaCl) which uses
+  `x25519-dalek` for key agreement
+
+[crypto_box]: https://github.com/RustCrypto/AEADs/tree/master/crypto_box


### PR DESCRIPTION
The `crypto_box` crate provides a pure Rust implementation of the public-key authenticated encryption primitive from NaCl which combines X25519 + XSalsa20Poly1305 (a.k.a. "Curve25519XSalsa20Poly1305")

This commit adds a link to it case x25519-dalek users are interested in using it as part of a hybrid cryptosystem.