### PR TITLE
Bump criterion version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ zeroize = { version = "1", default-features = false, features = ["zeroize_derive
 
 [dev-dependencies]
 bincode = "1"
-criterion = "0.2"
+criterion = "0.3.0"
 
 [[bench]]
 name = "x25519"


### PR DESCRIPTION
Note this allows the use of benchmark comparison tooling such as [critcmp](https://github.com/BurntSushi/critcmp).