### PR TITLE
'Secret' trait for unified DH

### DIFF
--- a/benches/x25519.rs
+++ b/benches/x25519.rs
@@ -21,6 +21,7 @@ use criterion::Criterion;
 
 use rand_core::OsRng;
 
+use x25519_dalek::Secret;
 use x25519_dalek::EphemeralSecret;
 use x25519_dalek::PublicKey;
 


### PR DESCRIPTION
Introduced a `Secret` trait to encapsulate Diffie-Hellman functionality of both `StaticSecret` and `EphemeralSecret`. 

Any overlaying logic would not care if it calculates DH on a static or ephemeral secret. This would enable to build generic interfaces using the trait as a DH mediator. 

For example X3DH uses static and ephemeral keys during it's agreement calculation:
https://www.signal.org/docs/specifications/x3dh/#sending-the-initial-message