### PR TITLE
Update curve25519-dalek to version 3.0.0.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ travis-ci = { repository = "dalek-cryptography/x25519-dalek", branch = "master"}
 features = ["nightly"]
 
 [dependencies]
-curve25519-dalek = { version = "2", default-features = false }
+curve25519-dalek = { version = "3", default-features = false }
 rand_core = { version = "0.5", default-features = false }
 # `serde` is renamed to `our_serde` in order to avoid a name collision between
 # importing the serde dependency and enabling the curve25519-dalek/serde feature


### PR DESCRIPTION
This allows unifying dependencies with other crates using the `3.x` series of
the curve library.  It is a semver patch-level change, because the x25519-dalek
API does not expose any details of the underlying curve implementation.