### PR TITLE
Add PartialEq derive to PublicKey

### DIFF
--- a/src/x25519.rs
+++ b/src/x25519.rs
@@ -29,7 +29,7 @@ use zeroize::Zeroize;
     feature = "serde",
     derive(our_serde::Serialize, our_serde::Deserialize)
 )]
-#[derive(Copy, Clone, Debug)]
+#[derive(PartialEq, Copy, Clone, Debug)]
 pub struct PublicKey(pub(crate) MontgomeryPoint);
 
 impl From<[u8; 32]> for PublicKey {

--- a/src/x25519.rs
+++ b/src/x25519.rs
@@ -29,7 +29,7 @@ use zeroize::Zeroize;
     feature = "serde",
     derive(our_serde::Serialize, our_serde::Deserialize)
 )]
-#[derive(PartialEq, Copy, Clone, Debug)]
+#[derive(PartialEq, Eq, Hash, Copy, Clone, Debug)]
 pub struct PublicKey(pub(crate) MontgomeryPoint);
 
 impl From<[u8; 32]> for PublicKey {


### PR DESCRIPTION
Adds PartialEq, Eq, and Hash to derive statement for PublicKey.
Derives from the PartialEq impl for MontgomeryPoint.

Seemed like this was an easy win so users of this crate can use the PartialEq derive macro on structs that use PublicKey!