### PR TITLE
Threads the `fiat_{u32,u64}_backend` features through the feature set

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 # - update CHANGELOG
 version = "1.1.0"
 authors = [
-    "Isis Lovecruft <isis@patternsinthevoid.net>", 
+    "Isis Lovecruft <isis@patternsinthevoid.net>",
     "DebugSteven <debugsteven@gmail.com>",
     "Henry de Valence <hdevalence@hdevalence.ca>",
 ]
@@ -55,3 +55,5 @@ std = ["curve25519-dalek/std"]
 nightly = ["curve25519-dalek/nightly"]
 u64_backend = ["curve25519-dalek/u64_backend"]
 u32_backend = ["curve25519-dalek/u32_backend"]
+fiat_u64_backend = ["curve25519-dalek/fiat_u64_backend"]
+fiat_u32_backend = ["curve25519-dalek/fiat_u32_backend"]


### PR DESCRIPTION
This allows the fiat backends introduced in [curve25519-dalek/#342](https://github.com/dalek-cryptography/curve25519-dalek/pull/342) to be used from an x25519 import without cumbersome overrides.