### PR TITLE
Added conversion from ed25519 Public and Private Key

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ rand_core = { version = "0.5", default-features = false }
 # importing the serde dependency and enabling the curve25519-dalek/serde feature
 our_serde = { package = "serde", version = "1", default-features = false, optional = true, features = ["derive"] }
 zeroize = { version = "1", default-features = false, features = ["zeroize_derive"] }
+ed25519-dalek = {version = "1.0.1", optional = true}
 
 [dev-dependencies]
 bincode = "1"
@@ -55,3 +56,4 @@ std = ["curve25519-dalek/std"]
 nightly = ["curve25519-dalek/nightly"]
 u64_backend = ["curve25519-dalek/u64_backend"]
 u32_backend = ["curve25519-dalek/u32_backend"]
+ed25519-dalek-conv = ["ed25519-dalek"]


### PR DESCRIPTION
I added the option for conversion from ed25519-dalek. I implemented this to make procedures possible, where both Diffie-Hellmann and Signing is required. Please review this code carefully as I don't really understand the underlying math.