### PR TITLE
Bump rand_core to 0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ features = ["nightly", "reusable_secrets", "serde"]
 
 [dependencies]
 curve25519-dalek = { version = "3", default-features = false }
-rand_core = { version = "0.5", default-features = false }
+rand_core = { version = "0.6", default-features = false, features = ["getrandom"] }
 # `serde` is renamed to `our_serde` in order to avoid a name collision between
 # importing the serde dependency and enabling the curve25519-dalek/serde feature
 our_serde = { package = "serde", version = "1", default-features = false, optional = true, features = ["derive"] }


### PR DESCRIPTION
The CHANGELOG for rand_core is [here](https://github.com/rust-random/rand/blob/master/rand_core/CHANGELOG.md).