### PR TITLE
Use zeroize 1 or newer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ rand_core = { version = "0.5", default-features = false }
 # `serde` is renamed to `our_serde` in order to avoid a name collision between
 # importing the serde dependency and enabling the curve25519-dalek/serde feature
 our_serde = { package = "serde", version = "1", default-features = false, optional = true, features = ["derive"] }
-zeroize = { version = "=1.3", default-features = false, features = ["zeroize_derive"] }
+zeroize = { version = "1", default-features = false, features = ["zeroize_derive"] }
 
 [dev-dependencies]
 bincode = "1"


### PR DESCRIPTION
Version =1.3 was set so the library builds on older rust versions. But
this won't allow to build the library if some other dependency
requires a newer version.

See https://gitlab.gnome.org/GNOME/fractal/-/issues/1016#note_1442659