### PR TITLE
Make `SharedSecret` (de)serializable

### DIFF
--- a/src/x25519.rs
+++ b/src/x25519.rs
@@ -210,6 +210,11 @@ impl<'a> From<&'a StaticSecret> for PublicKey {
 ///
 /// Each party computes this using their [`EphemeralSecret`] or [`StaticSecret`] and their
 /// counterparty's [`PublicKey`].
+#[cfg_attr(feature = "serde", serde(crate = "our_serde"))]
+#[cfg_attr(
+    feature = "serde",
+    derive(our_serde::Serialize, our_serde::Deserialize)
+)]
 #[derive(Zeroize)]
 #[zeroize(drop)]
 pub struct SharedSecret(pub(crate) MontgomeryPoint);


### PR DESCRIPTION
Hello!

All is in the title: I'd like for `SharedSecret` to be (de)serializable. Is this fine?