### PR TITLE
Add `StaticSecret::as_bytes` accessor  (see issue #101)

### DIFF
--- a/src/x25519.rs
+++ b/src/x25519.rs
@@ -190,6 +190,12 @@ impl StaticSecret {
     pub fn to_bytes(&self) -> [u8; 32] {
         self.0.to_bytes()
     }
+
+    /// View this key as a byte array.
+    #[inline]
+    pub fn as_bytes(&self) -> &[u8; 32] {
+        self.0.as_bytes()
+    }
 }
 
 impl From<[u8; 32]> for StaticSecret {


### PR DESCRIPTION
This pull request is trivial and just adds the `as_bytes` accessor to `StaticSecret`, thus solving #101.

I didn't add any test-cases as it's a trivial accessor.
