### PR TITLE
[version]: Allow `zeroize` version 1.5.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 # - update html_root_url
 # - update CHANGELOG
 # - if any changes were made to README.md, mirror them in src/lib.rs docs
-version = "1.2.0"
+version = "1.2.1"
 authors = [
     "Isis Lovecruft <isis@patternsinthevoid.net>",
     "DebugSteven <debugsteven@gmail.com>",
@@ -39,7 +39,7 @@ rand_core = { version = "0.5", default-features = false }
 # `serde` is renamed to `our_serde` in order to avoid a name collision between
 # importing the serde dependency and enabling the curve25519-dalek/serde feature
 our_serde = { package = "serde", version = "1", default-features = false, optional = true, features = ["derive"] }
-zeroize = { version = "=1.3", default-features = false, features = ["zeroize_derive"] }
+zeroize = { version = "1", default-features = false, features = ["zeroize_derive"] }
 
 [dev-dependencies]
 bincode = "1"


### PR DESCRIPTION
## Motivation

Currently cryptographic libraries are held back by the pinned dependency on `zeroize`. Given that tests don't fail (either unit tests in this repo, or hyperledger/ursa), I took the liberty of unpinning the dependency in a compatible fashion.  

## Drawbacks

If some subtle change in the behaviour of `zeroize` was introduced, and it wasn't caught by tests in Hyperledger/ursa, it might be non-trivial to find. 