### PR TITLE
Add feature `getrandom`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ harness = false
 
 [features]
 default = ["alloc", "precomputed-tables", "zeroize"]
+getrandom = ["rand_core/getrandom"]
 zeroize = ["dep:zeroize", "curve25519-dalek/zeroize"]
 serde = ["dep:serde", "curve25519-dalek/serde"]
 alloc = ["curve25519-dalek/alloc", "serde?/alloc", "zeroize?/alloc"]

--- a/README.md
+++ b/README.md
@@ -28,23 +28,21 @@ up on modern public key cryptography and have learned a nifty trick called
 kittens will be able to secretly organise to find their mittens, and then spend
 the rest of the afternoon nomming some yummy pie!
 
-First, Alice uses `EphemeralSecret::new()` and then
+First, Alice uses `EphemeralSecret::random()` and then
 `PublicKey::from()` to produce her secret and public keys:
 
 ```rust
-use rand_core::OsRng;
 use x25519_dalek::{EphemeralSecret, PublicKey};
 
-let alice_secret = EphemeralSecret::new(OsRng);
+let alice_secret = EphemeralSecret::random();
 let alice_public = PublicKey::from(&alice_secret);
 ```
 
 Bob does the same:
 
 ```rust
-# use rand_core::OsRng;
 # use x25519_dalek::{EphemeralSecret, PublicKey};
-let bob_secret = EphemeralSecret::new(OsRng);
+let bob_secret = EphemeralSecret::random();
 let bob_public = PublicKey::from(&bob_secret);
 ```
 

--- a/benches/x25519.rs
+++ b/benches/x25519.rs
@@ -19,12 +19,12 @@ use x25519_dalek::EphemeralSecret;
 use x25519_dalek::PublicKey;
 
 fn bench_diffie_hellman(c: &mut Criterion) {
-    let bob_secret = EphemeralSecret::new(OsRng);
+    let bob_secret = EphemeralSecret::random_from_rng(OsRng);
     let bob_public = PublicKey::from(&bob_secret);
 
     c.bench_function("diffie_hellman", move |b| {
         b.iter_with_setup(
-            || EphemeralSecret::new(OsRng),
+            || EphemeralSecret::random_from_rng(OsRng),
             |alice_secret| alice_secret.diffie_hellman(&bob_public),
         )
     });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,14 +50,14 @@
 //! kittens will be able to secretly organise to find their mittens, and then spend
 //! the rest of the afternoon nomming some yummy pie!
 //!
-//! First, Alice uses `EphemeralSecret::new()` and then
+//! First, Alice uses `EphemeralSecret::random_from_rng` and then
 //! `PublicKey::from()` to produce her secret and public keys:
 //!
 //! ```rust
 //! use rand_core::OsRng;
 //! use x25519_dalek::{EphemeralSecret, PublicKey};
 //!
-//! let alice_secret = EphemeralSecret::new(OsRng);
+//! let alice_secret = EphemeralSecret::random_from_rng(OsRng);
 //! let alice_public = PublicKey::from(&alice_secret);
 //! ```
 //!
@@ -66,7 +66,7 @@
 //! ```rust
 //! # use rand_core::OsRng;
 //! # use x25519_dalek::{EphemeralSecret, PublicKey};
-//! let bob_secret = EphemeralSecret::new(OsRng);
+//! let bob_secret = EphemeralSecret::random_from_rng(OsRng);
 //! let bob_public = PublicKey::from(&bob_secret);
 //! ```
 //!
@@ -77,9 +77,9 @@
 //! ```rust
 //! # use rand_core::OsRng;
 //! # use x25519_dalek::{EphemeralSecret, PublicKey};
-//! # let alice_secret = EphemeralSecret::new(OsRng);
+//! # let alice_secret = EphemeralSecret::random_from_rng(OsRng);
 //! # let alice_public = PublicKey::from(&alice_secret);
-//! # let bob_secret = EphemeralSecret::new(OsRng);
+//! # let bob_secret = EphemeralSecret::random_from_rng(OsRng);
 //! # let bob_public = PublicKey::from(&bob_secret);
 //! let alice_shared_secret = alice_secret.diffie_hellman(&bob_public);
 //! ```
@@ -89,9 +89,9 @@
 //! ```rust
 //! # use rand_core::OsRng;
 //! # use x25519_dalek::{EphemeralSecret, PublicKey};
-//! # let alice_secret = EphemeralSecret::new(OsRng);
+//! # let alice_secret = EphemeralSecret::random_from_rng(OsRng);
 //! # let alice_public = PublicKey::from(&alice_secret);
-//! # let bob_secret = EphemeralSecret::new(OsRng);
+//! # let bob_secret = EphemeralSecret::random_from_rng(OsRng);
 //! # let bob_public = PublicKey::from(&bob_secret);
 //! let bob_shared_secret = bob_secret.diffie_hellman(&alice_public);
 //! ```
@@ -101,9 +101,9 @@
 //! ```rust
 //! # use rand_core::OsRng;
 //! # use x25519_dalek::{EphemeralSecret, PublicKey};
-//! # let alice_secret = EphemeralSecret::new(OsRng);
+//! # let alice_secret = EphemeralSecret::random_from_rng(OsRng);
 //! # let alice_public = PublicKey::from(&alice_secret);
-//! # let bob_secret = EphemeralSecret::new(OsRng);
+//! # let bob_secret = EphemeralSecret::random_from_rng(OsRng);
 //! # let bob_public = PublicKey::from(&bob_secret);
 //! # let alice_shared_secret = alice_secret.diffie_hellman(&bob_public);
 //! # let bob_shared_secret = bob_secret.diffie_hellman(&alice_public);

--- a/src/x25519.rs
+++ b/src/x25519.rs
@@ -82,11 +82,7 @@ impl EphemeralSecret {
         note = "Renamed to `random_from_rng`. This will be removed in 2.1.0"
     )]
     pub fn new<T: RngCore + CryptoRng>(mut csprng: T) -> Self {
-        let mut bytes = [0u8; 32];
-
-        csprng.fill_bytes(&mut bytes);
-
-        EphemeralSecret(Scalar::from_bits_clamped(bytes))
+        Self::random_from_rng(&mut csprng)
     }
 
     /// Generate a new [`EphemeralSecret`] with the supplied RNG.
@@ -150,11 +146,7 @@ impl ReusableSecret {
         note = "Renamed to `random_from_rng`. This will be removed in 2.1.0."
     )]
     pub fn new<T: RngCore + CryptoRng>(mut csprng: T) -> Self {
-        let mut bytes = [0u8; 32];
-
-        csprng.fill_bytes(&mut bytes);
-
-        ReusableSecret(Scalar::from_bits_clamped(bytes))
+        Self::random_from_rng(&mut csprng)
     }
 
     /// Generate a new [`ReusableSecret`] with the supplied RNG.
@@ -216,11 +208,7 @@ impl StaticSecret {
         note = "Renamed to `random_from_rng`. This will be removed in 2.1.0"
     )]
     pub fn new<T: RngCore + CryptoRng>(mut csprng: T) -> Self {
-        let mut bytes = [0u8; 32];
-
-        csprng.fill_bytes(&mut bytes);
-
-        StaticSecret(Scalar::from_bits_clamped(bytes))
+        Self::random_from_rng(&mut csprng)
     }
 
     /// Generate a new [`StaticSecret`] with the supplied RNG.

--- a/src/x25519.rs
+++ b/src/x25519.rs
@@ -77,6 +77,19 @@ impl EphemeralSecret {
     }
 
     /// Generate an x25519 [`EphemeralSecret`] key with the supplied [`rand_core::OsRng`]
+    #[deprecated(
+        since = "2.0.0",
+        note = "Renamed to `random_from_rng`. This will be removed in 2.1.0"
+    )]
+    pub fn new<T: RngCore + CryptoRng>(mut csprng: T) -> Self {
+        let mut bytes = [0u8; 32];
+
+        csprng.fill_bytes(&mut bytes);
+
+        EphemeralSecret(Scalar::from_bits_clamped(bytes))
+    }
+
+    /// Generate an x25519 [`EphemeralSecret`] key with the supplied [`rand_core::OsRng`]
     pub fn random_from_rng<T: RngCore + CryptoRng>(mut csprng: T) -> Self {
         let mut bytes = [0u8; 32];
 
@@ -84,6 +97,7 @@ impl EphemeralSecret {
 
         EphemeralSecret(Scalar::from_bits_clamped(bytes))
     }
+
     /// Generate an x25519 [`EphemeralSecret`]
     #[cfg(feature = "getrandom")]
     pub fn random() -> Self {
@@ -132,6 +146,20 @@ impl ReusableSecret {
 
     /// Generate a non-serializeable x25519 [`ReusableSecret`] key
     /// with the supplied [`rand_core::OsRng`].
+    #[deprecated(
+        since = "2.0.0",
+        note = "Renamed to `random_from_rng`. This will be removed in 2.1.0."
+    )]
+    pub fn new<T: RngCore + CryptoRng>(mut csprng: T) -> Self {
+        let mut bytes = [0u8; 32];
+
+        csprng.fill_bytes(&mut bytes);
+
+        ReusableSecret(Scalar::from_bits_clamped(bytes))
+    }
+
+    /// Generate a non-serializeable x25519 [`ReusableSecret`] key
+    /// with the supplied [`rand_core::OsRng`].
     pub fn random_from_rng<T: RngCore + CryptoRng>(mut csprng: T) -> Self {
         let mut bytes = [0u8; 32];
 
@@ -139,6 +167,7 @@ impl ReusableSecret {
 
         ReusableSecret(Scalar::from_bits_clamped(bytes))
     }
+
     /// Generate a non-serializeable x25519 [`ReusableSecret`].
     #[cfg(feature = "getrandom")]
     pub fn random() -> Self {
@@ -184,6 +213,19 @@ impl StaticSecret {
     }
 
     /// Generate a new [`StaticSecret`] key with the supplied [`rand_core::OsRng`].
+    #[deprecated(
+        since = "2.0.0",
+        note = "Renamed to `random_from_rng`. This will be removed in 2.1.0"
+    )]
+    pub fn new<T: RngCore + CryptoRng>(mut csprng: T) -> Self {
+        let mut bytes = [0u8; 32];
+
+        csprng.fill_bytes(&mut bytes);
+
+        StaticSecret(Scalar::from_bits_clamped(bytes))
+    }
+
+    /// Generate a new [`StaticSecret`] key with the supplied [`rand_core::OsRng`].
     pub fn random_from_rng<T: RngCore + CryptoRng>(mut csprng: T) -> Self {
         let mut bytes = [0u8; 32];
 
@@ -192,7 +234,7 @@ impl StaticSecret {
         StaticSecret(Scalar::from_bits_clamped(bytes))
     }
 
-    /// Generate a new [`StaticSecret`] key.
+    /// Generate a [`StaticSecret`] key.
     #[cfg(feature = "getrandom")]
     pub fn random() -> Self {
         Self::random_from_rng(&mut rand_core::OsRng)

--- a/src/x25519.rs
+++ b/src/x25519.rs
@@ -138,7 +138,7 @@ impl ReusableSecret {
 
         ReusableSecret(Scalar::from_bits_clamped(bytes))
     }
-    /// Generate a non-serializeable x25519 [`ReuseableSecret`] key using [`rand_core::OsRng`].
+    /// Generate a non-serializeable x25519 [`ReusableSecret`] key using [`rand_core::OsRng`].
     #[cfg(feature = "getrandom")]
     pub fn random() -> Self {
         Self::new(&mut rand_core::OsRng)

--- a/src/x25519.rs
+++ b/src/x25519.rs
@@ -76,7 +76,7 @@ impl EphemeralSecret {
         SharedSecret(self.0 * their_public.0)
     }
 
-    /// Generate an x25519 [`EphemeralSecret`] key with the supplied [`rand_core::OsRng`]
+    /// Generate a new [`EphemeralSecret`] with the supplied RNG.
     #[deprecated(
         since = "2.0.0",
         note = "Renamed to `random_from_rng`. This will be removed in 2.1.0"
@@ -89,7 +89,7 @@ impl EphemeralSecret {
         EphemeralSecret(Scalar::from_bits_clamped(bytes))
     }
 
-    /// Generate an x25519 [`EphemeralSecret`] key with the supplied [`rand_core::OsRng`]
+    /// Generate a new [`EphemeralSecret`] with the supplied RNG.
     pub fn random_from_rng<T: RngCore + CryptoRng>(mut csprng: T) -> Self {
         let mut bytes = [0u8; 32];
 
@@ -98,7 +98,7 @@ impl EphemeralSecret {
         EphemeralSecret(Scalar::from_bits_clamped(bytes))
     }
 
-    /// Generate an x25519 [`EphemeralSecret`]
+    /// Generate a new [`EphemeralSecret`].
     #[cfg(feature = "getrandom")]
     pub fn random() -> Self {
         Self::random_from_rng(&mut rand_core::OsRng)
@@ -144,8 +144,7 @@ impl ReusableSecret {
         SharedSecret(self.0 * their_public.0)
     }
 
-    /// Generate a non-serializeable x25519 [`ReusableSecret`] key
-    /// with the supplied [`rand_core::OsRng`].
+    /// Generate a new [`ReusableSecret`] with the supplied RNG.
     #[deprecated(
         since = "2.0.0",
         note = "Renamed to `random_from_rng`. This will be removed in 2.1.0."
@@ -158,8 +157,7 @@ impl ReusableSecret {
         ReusableSecret(Scalar::from_bits_clamped(bytes))
     }
 
-    /// Generate a non-serializeable x25519 [`ReusableSecret`] key
-    /// with the supplied [`rand_core::OsRng`].
+    /// Generate a new [`ReusableSecret`] with the supplied RNG.
     pub fn random_from_rng<T: RngCore + CryptoRng>(mut csprng: T) -> Self {
         let mut bytes = [0u8; 32];
 
@@ -168,7 +166,7 @@ impl ReusableSecret {
         ReusableSecret(Scalar::from_bits_clamped(bytes))
     }
 
-    /// Generate a non-serializeable x25519 [`ReusableSecret`].
+    /// Generate a new [`ReusableSecret`].
     #[cfg(feature = "getrandom")]
     pub fn random() -> Self {
         Self::random_from_rng(&mut rand_core::OsRng)
@@ -212,7 +210,7 @@ impl StaticSecret {
         SharedSecret(self.0 * their_public.0)
     }
 
-    /// Generate a new [`StaticSecret`] key with the supplied [`rand_core::OsRng`].
+    /// Generate a new [`StaticSecret`] with the supplied RNG.
     #[deprecated(
         since = "2.0.0",
         note = "Renamed to `random_from_rng`. This will be removed in 2.1.0"
@@ -225,7 +223,7 @@ impl StaticSecret {
         StaticSecret(Scalar::from_bits_clamped(bytes))
     }
 
-    /// Generate a new [`StaticSecret`] key with the supplied [`rand_core::OsRng`].
+    /// Generate a new [`StaticSecret`] with the supplied RNG.
     pub fn random_from_rng<T: RngCore + CryptoRng>(mut csprng: T) -> Self {
         let mut bytes = [0u8; 32];
 
@@ -234,7 +232,7 @@ impl StaticSecret {
         StaticSecret(Scalar::from_bits_clamped(bytes))
     }
 
-    /// Generate a [`StaticSecret`] key.
+    /// Generate a new [`StaticSecret`].
     #[cfg(feature = "getrandom")]
     pub fn random() -> Self {
         Self::random_from_rng(&mut rand_core::OsRng)

--- a/src/x25519.rs
+++ b/src/x25519.rs
@@ -84,6 +84,11 @@ impl EphemeralSecret {
 
         EphemeralSecret(Scalar::from_bits_clamped(bytes))
     }
+    /// Generate an x25519 [`EphemeralSecret`] key using [`rand_core::OsRng`].
+    #[cfg(feature = "getrandom")]
+    pub fn random() -> Self {
+        Self::new(&mut rand_core::OsRng)
+    }
 }
 
 impl<'a> From<&'a EphemeralSecret> for PublicKey {
@@ -132,6 +137,11 @@ impl ReusableSecret {
         csprng.fill_bytes(&mut bytes);
 
         ReusableSecret(Scalar::from_bits_clamped(bytes))
+    }
+    /// Generate a non-serializeable x25519 [`ReuseableSecret`] key using [`rand_core::OsRng`].
+    #[cfg(feature = "getrandom")]
+    pub fn random() -> Self {
+        Self::new(&mut rand_core::OsRng)
     }
 }
 
@@ -184,6 +194,12 @@ impl StaticSecret {
     /// Extract this key's bytes for serialization.
     pub fn to_bytes(&self) -> [u8; 32] {
         self.0.to_bytes()
+    }
+
+    /// Generate an x25519 key key using [`rand_core::OsRng`].
+    #[cfg(feature = "getrandom")]
+    pub fn random() -> Self {
+        Self::new(&mut rand_core::OsRng)
     }
 }
 

--- a/tests/x25519_tests.rs
+++ b/tests/x25519_tests.rs
@@ -181,24 +181,52 @@ fn rfc7748_ladder_test2() {
     );
 }
 
+mod rand_core {
+
+    use super::*;
+    use ::rand_core::OsRng;
+
+    #[test]
+    fn ephemeral_from_rng() {
+        #[allow(deprecated)]
+        EphemeralSecret::new(OsRng);
+        EphemeralSecret::random_from_rng(OsRng);
+    }
+
+    #[test]
+    #[cfg(feature = "reusable_secrets")]
+    fn reusable_from_rng() {
+        #[allow(deprecated)]
+        ReusableSecret::new(OsRng);
+        ReusableSecret::random_from_rng(OsRng);
+    }
+
+    #[test]
+    fn static_from_rng() {
+        #[allow(deprecated)]
+        StaticSecret::new(OsRng);
+        StaticSecret::random_from_rng(OsRng);
+    }
+}
+
 #[cfg(feature = "getrandom")]
 mod getrandom {
 
     use super::*;
 
     #[test]
-    fn random_ephemeral_secret() {
+    fn ephemeral_random() {
         EphemeralSecret::random();
     }
 
     #[test]
     #[cfg(feature = "reusable_secrets")]
-    fn random_reusable_secret() {
+    fn reusable_random() {
         ReusableSecret::random();
     }
 
     #[test]
-    fn random_static_secret() {
+    fn static_random() {
         StaticSecret::random();
     }
 }

--- a/tests/x25519_tests.rs
+++ b/tests/x25519_tests.rs
@@ -181,20 +181,24 @@ fn rfc7748_ladder_test2() {
     );
 }
 
-#[test]
 #[cfg(feature = "getrandom")]
-fn random_ephemeral_secret() {
-    EphemeralSecret::random();
-}
+mod getrandom {
 
-#[test]
-#[cfg(all(feature = "getrandom", feature = "reusable_secrets"))]
-fn random_reusable_secret() {
-    ReusableSecret::random();
-}
+    use super::*;
 
-#[test]
-#[cfg(feature = "getrandom")]
-fn random_static_secret() {
-    StaticSecret::random();
+    #[test]
+    fn random_ephemeral_secret() {
+        EphemeralSecret::random();
+    }
+
+    #[test]
+    #[cfg(feature = "reusable_secrets")]
+    fn random_reusable_secret() {
+        ReusableSecret::random();
+    }
+
+    #[test]
+    fn random_static_secret() {
+        StaticSecret::random();
+    }
 }

--- a/tests/x25519_tests.rs
+++ b/tests/x25519_tests.rs
@@ -180,3 +180,21 @@ fn rfc7748_ladder_test2() {
         ]
     );
 }
+
+#[test]
+#[cfg(feature = "getrandom")]
+fn random_ephemeral_secret() {
+    EphemeralSecret::random();
+}
+
+#[test]
+#[cfg(all(feature = "getrandom", feature = "reusable_secrets"))]
+fn random_reusable_secret() {
+    ReusableSecret::random();
+}
+
+#[test]
+#[cfg(feature = "getrandom")]
+fn random_static_secret() {
+    StaticSecret::random();
+}


### PR DESCRIPTION
Fixes #85 
Supercedes #103 by re-rolling the commit with Co-authored-by @cipriancraciun (it was targeting main branch)

Provides the new feature `getrandom` with convenience `random()` functions (naming aligned to other daleks)