### PR TITLE
Fix `no std` by moving `get_random` feat dev-deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ features = ["nightly", "reusable_secrets", "serde"]
 
 [dependencies]
 curve25519-dalek = { version = "4.0.0-rc.0", default-features = false }
-rand_core = { version = "0.6", default-features = false, features = ["getrandom"] }
+rand_core = { version = "0.6", default-features = false }
 serde = { version = "1", default-features = false, optional = true, features = ["derive"] }
 zeroize = { version = "1", default-features = false, optional = true, features = ["zeroize_derive"] }
 
@@ -55,3 +55,5 @@ serde = ["dep:serde", "curve25519-dalek/serde"]
 alloc = ["curve25519-dalek/alloc", "serde?/alloc", "zeroize?/alloc"]
 precomputed-tables = ["curve25519-dalek/precomputed-tables"]
 reusable_secrets = []
+# docs: docsrs and doctest features
+docsrs = ["rand_core/getrandom"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ zeroize = { version = "1", default-features = false, optional = true, features =
 [dev-dependencies]
 bincode = "1"
 criterion = "0.3.0"
+rand_core = { version = "0.6", default-features = false, features = ["getrandom"] }
 
 [[bench]]
 name = "x25519"
@@ -55,5 +56,3 @@ serde = ["dep:serde", "curve25519-dalek/serde"]
 alloc = ["curve25519-dalek/alloc", "serde?/alloc", "zeroize?/alloc"]
 precomputed-tables = ["curve25519-dalek/precomputed-tables"]
 reusable_secrets = []
-# docs: docsrs and doctest features
-docsrs = ["rand_core/getrandom"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,8 +53,7 @@
 //! First, Alice uses `EphemeralSecret::new()` and then
 //! `PublicKey::from()` to produce her secret and public keys:
 //!
-#![cfg_attr(feature = "docsrs", doc = "```")]
-#![cfg_attr(not(feature = "docsrs"), doc = "```ignore")]
+//! ```rust
 //! use rand_core::OsRng;
 //! use x25519_dalek::{EphemeralSecret, PublicKey};
 //!
@@ -64,8 +63,7 @@
 //!
 //! Bob does the same:
 //!
-#![cfg_attr(feature = "docsrs", doc = "```")]
-#![cfg_attr(not(feature = "docsrs"), doc = "```ignore")]
+//! ```rust
 //! # use rand_core::OsRng;
 //! # use x25519_dalek::{EphemeralSecret, PublicKey};
 //! let bob_secret = EphemeralSecret::new(OsRng);
@@ -76,8 +74,7 @@
 //! loudly meows `bob_public` back to Alice.  Alice now computes her
 //! shared secret with Bob by doing:
 //!
-#![cfg_attr(feature = "docsrs", doc = "```")]
-#![cfg_attr(not(feature = "docsrs"), doc = "```ignore")]
+//! ```rust
 //! # use rand_core::OsRng;
 //! # use x25519_dalek::{EphemeralSecret, PublicKey};
 //! # let alice_secret = EphemeralSecret::new(OsRng);
@@ -89,8 +86,7 @@
 //!
 //! Similarly, Bob computes a shared secret by doing:
 //!
-#![cfg_attr(feature = "docsrs", doc = "```")]
-#![cfg_attr(not(feature = "docsrs"), doc = "```ignore")]
+//! ```rust
 //! # use rand_core::OsRng;
 //! # use x25519_dalek::{EphemeralSecret, PublicKey};
 //! # let alice_secret = EphemeralSecret::new(OsRng);
@@ -102,8 +98,7 @@
 //!
 //! These secrets are the same:
 //!
-#![cfg_attr(feature = "docsrs", doc = "```")]
-#![cfg_attr(not(feature = "docsrs"), doc = "```ignore")]
+//! ```rust
 //! # use rand_core::OsRng;
 //! # use x25519_dalek::{EphemeralSecret, PublicKey};
 //! # let alice_secret = EphemeralSecret::new(OsRng);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,8 @@
 //! First, Alice uses `EphemeralSecret::new()` and then
 //! `PublicKey::from()` to produce her secret and public keys:
 //!
-//! ```rust
+#![cfg_attr(feature = "docsrs", doc = "```")]
+#![cfg_attr(not(feature = "docsrs"), doc = "```ignore")]
 //! use rand_core::OsRng;
 //! use x25519_dalek::{EphemeralSecret, PublicKey};
 //!
@@ -63,7 +64,8 @@
 //!
 //! Bob does the same:
 //!
-//! ```rust
+#![cfg_attr(feature = "docsrs", doc = "```")]
+#![cfg_attr(not(feature = "docsrs"), doc = "```ignore")]
 //! # use rand_core::OsRng;
 //! # use x25519_dalek::{EphemeralSecret, PublicKey};
 //! let bob_secret = EphemeralSecret::new(OsRng);
@@ -74,7 +76,8 @@
 //! loudly meows `bob_public` back to Alice.  Alice now computes her
 //! shared secret with Bob by doing:
 //!
-//! ```rust
+#![cfg_attr(feature = "docsrs", doc = "```")]
+#![cfg_attr(not(feature = "docsrs"), doc = "```ignore")]
 //! # use rand_core::OsRng;
 //! # use x25519_dalek::{EphemeralSecret, PublicKey};
 //! # let alice_secret = EphemeralSecret::new(OsRng);
@@ -86,7 +89,8 @@
 //!
 //! Similarly, Bob computes a shared secret by doing:
 //!
-//! ```rust
+#![cfg_attr(feature = "docsrs", doc = "```")]
+#![cfg_attr(not(feature = "docsrs"), doc = "```ignore")]
 //! # use rand_core::OsRng;
 //! # use x25519_dalek::{EphemeralSecret, PublicKey};
 //! # let alice_secret = EphemeralSecret::new(OsRng);
@@ -98,7 +102,8 @@
 //!
 //! These secrets are the same:
 //!
-//! ```rust
+#![cfg_attr(feature = "docsrs", doc = "```")]
+#![cfg_attr(not(feature = "docsrs"), doc = "```ignore")]
 //! # use rand_core::OsRng;
 //! # use x25519_dalek::{EphemeralSecret, PublicKey};
 //! # let alice_secret = EphemeralSecret::new(OsRng);

--- a/src/x25519.rs
+++ b/src/x25519.rs
@@ -267,7 +267,8 @@ impl SharedSecret {
 /// cannot use the better, safer, and faster ephemeral DH API.
 ///
 /// # Example
-/// ```
+#[cfg_attr(feature = "docsrs", doc = "```")]
+#[cfg_attr(not(feature = "docsrs"), doc = "```ignore")]
 /// use rand_core::OsRng;
 /// use rand_core::RngCore;
 ///

--- a/src/x25519.rs
+++ b/src/x25519.rs
@@ -267,8 +267,7 @@ impl SharedSecret {
 /// cannot use the better, safer, and faster ephemeral DH API.
 ///
 /// # Example
-#[cfg_attr(feature = "docsrs", doc = "```")]
-#[cfg_attr(not(feature = "docsrs"), doc = "```ignore")]
+/// ```rust
 /// use rand_core::OsRng;
 /// use rand_core::RngCore;
 ///


### PR DESCRIPTION
Fixes https://github.com/dalek-cryptography/x25519-dalek/issues/111

Move the get_random weak feature under rand_core as dev-dependency so we don't bring std that it brings.

Repeat of #112 due to release/2.0 branch got nuked