### PR TITLE
Update to new `Scalar` API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Entries are listed in reverse chronological order.
 
 # 2.x Series
 
+
+## 2.0.0-rc.3
+
+* Change: `StaticSecret` serialization and `to_bytes()` no longer returns clamped integers. Clamping is still always done during scalar-point multiplication.
+
 ## 2.0.0-rc.2
 
 * Update MSRV to 1.60.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,8 +166,7 @@ dependencies = [
 [[package]]
 name = "curve25519-dalek"
 version = "4.0.0-rc.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d4ba9852b42210c7538b75484f9daa0655e9a3ac04f693747bb0f02cf3cfe16"
+source = "git+https://github.com/rozbb/curve25519-dalek.git?branch=scalar-always-reduced#5d1aae2b391d38c3a3abd7776edbe6499cc1dc8d"
 dependencies = [
  "cfg-if",
  "fiat-crypto",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ rustdoc-args = [
 features = ["reusable_secrets", "serde"]
 
 [dependencies]
-curve25519-dalek = { version = "4.0.0-rc.0", default-features = false }
+curve25519-dalek = { git = "https://github.com/rozbb/curve25519-dalek.git", branch = "scalar-always-reduced", default-features = false }
 rand_core = { version = "0.6", default-features = false }
 serde = { version = "1", default-features = false, optional = true, features = ["derive"] }
 zeroize = { version = "1", default-features = false, optional = true, features = ["zeroize_derive"] }

--- a/src/x25519.rs
+++ b/src/x25519.rs
@@ -14,9 +14,7 @@
 //! This implements x25519 key exchange as specified by Mike Hamburg
 //! and Adam Langley in [RFC7748](https://tools.ietf.org/html/rfc7748).
 
-use curve25519_dalek::{
-    edwards::EdwardsPoint, montgomery::MontgomeryPoint, scalar::clamp_integer, traits::IsIdentity,
-};
+use curve25519_dalek::{edwards::EdwardsPoint, montgomery::MontgomeryPoint, traits::IsIdentity};
 
 use rand_core::CryptoRng;
 use rand_core::RngCore;
@@ -94,10 +92,10 @@ impl EphemeralSecret {
 
     /// Generate a new [`EphemeralSecret`] with the supplied RNG.
     pub fn random_from_rng<T: RngCore + CryptoRng>(mut csprng: T) -> Self {
-        // Generate random bytes. The secret key is the clamping of this.
+        // The secret key is random bytes. Clamping is done later.
         let mut bytes = [0u8; 32];
         csprng.fill_bytes(&mut bytes);
-        EphemeralSecret(clamp_integer(bytes))
+        EphemeralSecret(bytes)
     }
 
     /// Generate a new [`EphemeralSecret`].
@@ -157,10 +155,10 @@ impl ReusableSecret {
 
     /// Generate a new [`ReusableSecret`] with the supplied RNG.
     pub fn random_from_rng<T: RngCore + CryptoRng>(mut csprng: T) -> Self {
-        // Generate random bytes. The secret key is the clamping of this.
+        // The secret key is random bytes. Clamping is done later.
         let mut bytes = [0u8; 32];
         csprng.fill_bytes(&mut bytes);
-        ReusableSecret(clamp_integer(bytes))
+        ReusableSecret(bytes)
     }
 
     /// Generate a new [`ReusableSecret`].
@@ -218,10 +216,10 @@ impl StaticSecret {
 
     /// Generate a new [`StaticSecret`] with the supplied RNG.
     pub fn random_from_rng<T: RngCore + CryptoRng>(mut csprng: T) -> Self {
-        // Generate random bytes. The secret key is the clamping of this.
+        // The secret key is random bytes. Clamping is done later.
         let mut bytes = [0u8; 32];
         csprng.fill_bytes(&mut bytes);
-        StaticSecret(clamp_integer(bytes))
+        StaticSecret(bytes)
     }
 
     /// Generate a new [`StaticSecret`].
@@ -247,7 +245,7 @@ impl StaticSecret {
 impl From<[u8; 32]> for StaticSecret {
     /// Load a secret key from a byte array.
     fn from(bytes: [u8; 32]) -> StaticSecret {
-        StaticSecret(clamp_integer(bytes))
+        StaticSecret(bytes)
     }
 }
 

--- a/tests/x25519_tests.rs
+++ b/tests/x25519_tests.rs
@@ -60,11 +60,9 @@ fn serde_bincode_static_secret_roundtrip() {
 #[cfg(feature = "serde")]
 fn serde_bincode_static_secret_matches_from_bytes() {
     use bincode;
-    use curve25519_dalek::scalar::clamp_integer;
 
     let expected = StaticSecret::from([0x24; 32]);
-    let clamped_bytes = clamp_integer([0x24; 32]);
-    let decoded: StaticSecret = bincode::deserialize(&clamped_bytes).unwrap();
+    let decoded: StaticSecret = bincode::deserialize(&[0x24; 32]).unwrap();
 
     assert_eq!(decoded.to_bytes(), expected.to_bytes());
 }

--- a/tests/x25519_tests.rs
+++ b/tests/x25519_tests.rs
@@ -1,4 +1,4 @@
-use curve25519_dalek::{edwards::EdwardsPoint, scalar::Scalar};
+use curve25519_dalek::edwards::EdwardsPoint;
 
 use x25519_dalek::*;
 
@@ -10,11 +10,9 @@ fn byte_basepoint_matches_edwards_scalar_mul() {
         scalar_bytes[i] += 2;
 
         let result = x25519(scalar_bytes, X25519_BASEPOINT_BYTES);
-
-        let expected = {
-            let scalar = Scalar::from_bits_clamped(scalar_bytes);
-            EdwardsPoint::mul_base(&scalar).to_montgomery().to_bytes()
-        };
+        let expected = EdwardsPoint::mul_base_clamped(scalar_bytes)
+            .to_montgomery()
+            .to_bytes();
 
         assert_eq!(result, expected);
     }
@@ -62,9 +60,10 @@ fn serde_bincode_static_secret_roundtrip() {
 #[cfg(feature = "serde")]
 fn serde_bincode_static_secret_matches_from_bytes() {
     use bincode;
+    use curve25519_dalek::scalar::clamp_integer;
 
     let expected = StaticSecret::from([0x24; 32]);
-    let clamped_bytes = Scalar::from_bits_clamped([0x24; 32]).to_bytes();
+    let clamped_bytes = clamp_integer([0x24; 32]);
     let decoded: StaticSecret = bincode::deserialize(&clamped_bytes).unwrap();
 
     assert_eq!(decoded.to_bytes(), expected.to_bytes());


### PR DESCRIPTION
This removes all uses of `Scalar::[from_bits, from_bits_clamped}`. Some comments inline.

I'll update the git dependency once https://github.com/dalek-cryptography/curve25519-dalek/pull/519 drops.