### PR TITLE
Update `crypto_box` URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,4 +129,4 @@ copyright © Amy Wibowo ([@sailorhg](https://twitter.com/sailorhg))
   the NaCl family of encryption libraries (libsodium, TweetNaCl) which uses
   `x25519-dalek` for key agreement
 
-[crypto_box]: https://github.com/RustCrypto/AEADs/tree/master/crypto_box
+[crypto_box]: https://github.com/RustCrypto/nacl-compat/tree/master/crypto_box


### PR DESCRIPTION
The current `crypto_box` link returns a 404, RustCrypto moved it to a new `nacl-compat` repository. Thanks for the library!