### PR TITLE
chore: Release 2.0.0-rc.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,14 @@ Entries are listed in reverse chronological order.
 
 # 2.x Series
 
+* Note: All `x255919-dalek` 2.x releases are in sync with the underlying `curve25519-dalek` 4.x releases. 
 
 ## 2.0.0-rc.3
 
-* Change: `StaticSecret` serialization and `to_bytes()` no longer returns clamped integers. Clamping is still always done during scalar-point multiplication.
+* `StaticSecret` serialization and `to_bytes()` no longer returns clamped integers. Clamping is still always done during scalar-point multiplication.
+* Update underlying `curve25519_dalek` library to `4.0.0-rc.3` with notable changes:
+* [curve25519-dalek backend] now by default auto selects `simd` backend over `serial` where supported.
+
 
 ## 2.0.0-rc.2
 
@@ -16,7 +20,9 @@ Entries are listed in reverse chronological order.
 * Add `.as_bytes()` and `AsRef<[u8]>` for `Shared/StaticSecret`
 * Add `getrandom` feature to provide `random_from_rng` constructors
 * Make `StaticSecrets` optional via feature `static_secrets`
-* Update underlying `curve25519_dalek` library to `4.0.0-rc.2`
+* Update underlying `curve25519_dalek` library to `4.0.0-rc.2` with notable changes: 
+* [curve25519-dalek backend] additive features have been removed in favor of cfg based selection. 
+* [curve25519-dalek backend] now by default auto selects the appropriate word size over the previous default `32`.
 
 ## 2.0.0-pre.1
 
@@ -87,4 +93,6 @@ Entries are listed in reverse chronological order.
 ## 0.5.0
 
 * Adds support for static and ephemeral keys.
+
+[curve25519-dalek backend]: https://github.com/dalek-cryptography/curve25519-dalek/#backends 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ Entries are listed in reverse chronological order.
 ## 2.0.0-rc.3
 
 * `StaticSecret` serialization and `to_bytes()` no longer returns clamped integers. Clamping is still always done during scalar-point multiplication.
-* Update underlying `curve25519_dalek` library to `4.0.0-rc.3` with notable changes:
-* [curve25519-dalek backend] now by default auto selects `simd` backend over `serial` where supported.
+* Update underlying `curve25519_dalek` library to `4.0.0-rc.3`. Notable changes:
+    * [curve25519-dalek backend] now by default auto selects `simd` backend over `serial` where supported.
 
 
 ## 2.0.0-rc.2
@@ -20,9 +20,9 @@ Entries are listed in reverse chronological order.
 * Add `.as_bytes()` and `AsRef<[u8]>` for `Shared/StaticSecret`
 * Add `getrandom` feature to provide `random_from_rng` constructors
 * Make `StaticSecrets` optional via feature `static_secrets`
-* Update underlying `curve25519_dalek` library to `4.0.0-rc.2` with notable changes: 
-* [curve25519-dalek backend] additive features have been removed in favor of cfg based selection. 
-* [curve25519-dalek backend] now by default auto selects the appropriate word size over the previous default `32`.
+* Update underlying `curve25519_dalek` library to `4.0.0-rc.2`. Notable changes:
+    * [curve25519-dalek backend] additive features have been removed in favor of cfg based selection.
+    * [curve25519-dalek backend] now by default auto selects the appropriate word size over the previous default `32`.
 
 ## 2.0.0-pre.1
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,6 +107,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03e69e28e9f7f77debdedbaafa2866e1de9ba56df55a8bd7cfc724c25a09987c"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "criterion"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -187,16 +196,30 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.0.0-rc.2"
-source = "git+https://github.com/dalek-cryptography/curve25519-dalek.git?rev=f460ae149b0000695205cc78f560d74a2d3918eb#f460ae149b0000695205cc78f560d74a2d3918eb"
+version = "4.0.0-rc.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "436ace70fc06e06f7f689d2624dc4e2f0ea666efb5aa704215f7249ae6e047a7"
 dependencies = [
  "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
  "fiat-crypto",
- "packed_simd_2",
  "platforms",
+ "rustc_version",
  "serde",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fdaf97f4804dcebfa5862639bc9ce4121e82140bec2a987ac5140294865b5b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.12",
 ]
 
 [[package]]
@@ -299,12 +322,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
 
 [[package]]
-name = "libm"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fc7aa29613bd6a620df431842069224d8bc9011086b1db4c0e0cd47fa03ec9a"
-
-[[package]]
 name = "log"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -358,16 +375,6 @@ name = "os_str_bytes"
 version = "6.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ceedf44fb00f2d1984b0bc98102627ce622e083e49a5bacdb3e514fa4238e267"
-
-[[package]]
-name = "packed_simd_2"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1914cd452d8fccd6f9db48147b29fd4ae05bea9dc5d9ad578509f72415de282"
-dependencies = [
- "cfg-if",
- "libm",
-]
 
 [[package]]
 name = "platforms"
@@ -468,6 +475,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -487,6 +503,12 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "semver"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 
 [[package]]
 name = "serde"
@@ -682,7 +704,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "x25519-dalek"
-version = "2.0.0-rc.2"
+version = "2.0.0-rc.3"
 dependencies = [
  "bincode",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # - update html_root_url
 # - update CHANGELOG
 # - if any changes were made to README.md, mirror them in src/lib.rs docs
-version = "2.0.0-rc.2"
+version = "2.0.0-rc.3"
 authors = [
     "Isis Lovecruft <isis@patternsinthevoid.net>",
     "DebugSteven <debugsteven@gmail.com>",
@@ -38,7 +38,7 @@ rustdoc-args = [
 features = ["getrandom", "reusable_secrets", "serde", "static_secrets"]
 
 [dependencies]
-curve25519-dalek = { version = "4.0.0-rc.2", default-features = false }
+curve25519-dalek = { version = "=4.0.0-rc.3", default-features = false }
 rand_core = { version = "0.6", default-features = false }
 serde = { version = "1", default-features = false, optional = true, features = ["derive"] }
 zeroize = { version = "1", default-features = false, optional = true, features = ["zeroize_derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,3 @@ alloc = ["curve25519-dalek/alloc", "serde?/alloc", "zeroize?/alloc"]
 precomputed-tables = ["curve25519-dalek/precomputed-tables"]
 reusable_secrets = []
 static_secrets = []
-
-[patch.crates-io.curve25519-dalek]
-git = "https://github.com/dalek-cryptography/curve25519-dalek.git"
-rev = "f460ae149b0000695205cc78f560d74a2d3918eb"

--- a/README.md
+++ b/README.md
@@ -135,4 +135,5 @@ copyright © Amy Wibowo ([@sailorhg](https://twitter.com/sailorhg))
   the NaCl family of encryption libraries (libsodium, TweetNaCl) which uses
   `x25519-dalek` for key agreement
 
+[fiat]: https://github.com/mit-plv/fiat-crypto
 [crypto_box]: https://github.com/RustCrypto/nacl-compat/tree/master/crypto_box

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ To install, add the following to your project's `Cargo.toml`:
 
 ```toml
 [dependencies]
-x25519-dalek = "2.0.0-rc.2"
+x25519-dalek = "2.0.0-rc.3"
 ```
 
 # MSRV

--- a/README.md
+++ b/README.md
@@ -111,6 +111,12 @@ Current MSRV is 1.60.
 
 Documentation is available [here](https://docs.rs/x25519-dalek).
 
+# Performance and backend selection
+
+Performance is a secondary goal behind correctness, safety, and clarity, but we aim to be competitive with other implementations. To this end, we allow users to choose their _backend_, i.e., the underlying implementation of elliptic curve and scalar arithmetic. Different backends have different use cases. For example, if you demand formally verified code, you want to use the `fiat` backend (as it was generated from [Fiat Crypto][fiat]).
+
+Further instructions and details regarding backends can be found in the [curve25519-dalek docs](https://github.com/dalek-cryptography/curve25519-dalek#backends).
+
 # Note
 
 This code matches the [RFC7748][rfc7748] test vectors.


### PR DESCRIPTION
- curve25519 rc.3: https://github.com/dalek-cryptography/curve25519-dalek/pull/535
- ed25519 rc.3: https://github.com/dalek-cryptography/ed25519-dalek/pull/307
- Obviously tests fail until curve25519 rc.3 out
- Lock needs to be updated when curve25519 rc.3 out